### PR TITLE
Match selection cont

### DIFF
--- a/src/app/scout/[eventCode]/components/ball-scout-setup.tsx
+++ b/src/app/scout/[eventCode]/components/ball-scout-setup.tsx
@@ -6,13 +6,13 @@ import BackButton from "./common/back-button";
 import ContinueButton from "./common/continue-button";
 import { useContext, useState } from "react";
 import { cn } from "~/lib/utils";
-import { ScoutDataContext } from "../context";
+import { ScoutDataContext, ScoutScreenContext } from "../context";
 
 export default function BallScoutSetup() {
   const [redHumanPlayerSelected, setRedHumanPlayerSelected] = useState("");
   const [blueHumanPlayerSelected, setBlueHumanPlayerSelected] = useState("");
   const context = useContext(ScoutDataContext);
-
+  const screenContext = useContext(ScoutScreenContext);
   const updateTeamNumber = (teamNumber: number, allianceColour: string) => {
     if (context.alternateScoutData && context.setAlternateScoutData) {
       context.setAlternateScoutData({
@@ -133,11 +133,14 @@ export default function BallScoutSetup() {
       </div>
 
       <div className="flex flex-row justify-between my-20">
-        <BackButton />
+        <BackButton
+          onClick={() => screenContext.goToScreen("match-selection")}
+        />
         <ContinueButton
           disabled={
             redHumanPlayerSelected === "" || blueHumanPlayerSelected === ""
           }
+          onClick={() => screenContext.nextScreen()}
         />
       </div>
     </>

--- a/src/app/scout/[eventCode]/components/common/back-button.tsx
+++ b/src/app/scout/[eventCode]/components/common/back-button.tsx
@@ -2,10 +2,20 @@
 
 import { MoveLeftIcon } from "lucide-react";
 import { Button } from "~/components/ui/button";
-
-export default function BackButton() {
+export default function BackButton({
+  disabled,
+  onClick,
+}: {
+  disabled?: boolean;
+  onClick?: () => void;
+}) {
   return (
-    <Button className="!w-64" variant={"goBack"} size={"proceed"}>
+    <Button
+      className="!w-64"
+      variant={"goBack"}
+      size={"proceed"}
+      onClick={onClick}
+    >
       <MoveLeftIcon className="!size-6"></MoveLeftIcon>
       GO BACK
     </Button>

--- a/src/app/scout/[eventCode]/components/common/back-button.tsx
+++ b/src/app/scout/[eventCode]/components/common/back-button.tsx
@@ -3,6 +3,7 @@
 import { MoveLeftIcon } from "lucide-react";
 import { Button } from "~/components/ui/button";
 export default function BackButton({
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   disabled,
   onClick,
 }: {

--- a/src/app/scout/[eventCode]/components/common/continue-button.tsx
+++ b/src/app/scout/[eventCode]/components/common/continue-button.tsx
@@ -3,13 +3,20 @@
 import { MoveRightIcon } from "lucide-react";
 import { Button } from "~/components/ui/button";
 
-export default function ContinueButton({ disabled }: { disabled?: boolean }) {
+export default function ContinueButton({
+  disabled,
+  onClick,
+}: {
+  disabled?: boolean;
+  onClick?: () => void;
+}) {
   return (
     <Button
       className="!w-64"
       variant={"proceed"}
       size={"proceed"}
       disabled={disabled}
+      onClick={onClick}
     >
       Continue
       <MoveRightIcon className="!size-6"></MoveRightIcon>

--- a/src/app/scout/[eventCode]/components/common/match-selection-form.tsx
+++ b/src/app/scout/[eventCode]/components/common/match-selection-form.tsx
@@ -19,6 +19,7 @@ import {
   FormControl,
   FormField,
   FormItem,
+  FormLabel,
   FormMessage,
 } from "~/components/ui/form";
 import {
@@ -26,6 +27,9 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "~/components/ui/popover";
+import { useContext } from "react";
+import { ScoutDataContext } from "../../context";
+import { Checkbox } from "~/components/ui/checkbox";
 
 export default function MatchSelectionForm({
   setTeamSelectedEnabled: setTeamSelectedEnabled,
@@ -33,6 +37,8 @@ export default function MatchSelectionForm({
   setTeamSelectedEnabled: (value: boolean) => void;
 }) {
   const [isMatchSelectionOpen, setIsMatchSelectionOpen] = useState(false);
+  const [isReplayChecked, setIsReplayChecked] = useState(false);
+  const context = useContext(ScoutDataContext);
 
   const matchSelectionSchema = z.object({
     matchNumber: z
@@ -95,50 +101,56 @@ export default function MatchSelectionForm({
                       <CommandList className="mb-4">
                         <CommandEmpty>Nothing found</CommandEmpty>
                         <CommandGroup>
-                          {/* <CommandItem
-                            onSelect={(value) => {
-                              field.onChange(value);
-                              setIsMatchSelectionOpen(false);
-                            }}
-                          >
-                            Match 1
-                          </CommandItem> */}
-                          {Array.of(
-                            [
-                              1, 2, 3, 4, 5, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14,
-                              15,
-                            ].map((value, index) => (
-                              <CommandItem
-                                className="h-16 text-lg"
-                                key={`match-dropdown-item-${index + 1}`}
-                                onSelect={(value) => {
-                                  const cleanVal = value.split(" ");
+                          {context.matchSchedule.map((match, index) => (
+                            <CommandItem
+                              className="h-16 text-lg"
+                              key={`match-dropdown-item-${index + 1}`}
+                              onSelect={(value) => {
+                                const cleanVal = value.split(" ");
 
-                                  field.onChange(cleanVal[1]);
-                                  setIsMatchSelectionOpen(false);
-                                  setTeamSelectedEnabled(true);
-                                }}
-                              >
-                                {`Match ${value}`}
-                              </CommandItem>
-                            ))
-                          )}
-                          {/* <CommandItem
-                            onSelect={(value) => {
-                              const cleanVal = value.split(" ");
+                                field.onChange(cleanVal[1]);
+                                context.setMatchNumber(`Q${cleanVal[1]}`);
+                                setIsMatchSelectionOpen(false);
+                                setTeamSelectedEnabled(true);
+                                setIsReplayChecked(false);
 
-                              field.onChange(cleanVal[1]);
-                              setIsMatchSelectionOpen(false);
-                            }}
-                          >
-                            Match 3
-                          </CommandItem> */}
+                                context.setCurrentMatch(match);
+                              }}
+                            >
+                              {`Qualification ${match.matchNumber}`}
+                            </CommandItem>
+                          ))}
                         </CommandGroup>
                       </CommandList>
                     </Command>
                   </PopoverContent>
                 </Popover>
               </FormControl>
+              <div className="flex flex-row items-center">
+                <Checkbox
+                  className="size-12 "
+                  id="replay"
+                  checked={isReplayChecked}
+                  disabled={context.matchNumber === ""}
+                  onCheckedChange={(newValue) => {
+                    setIsReplayChecked(!isReplayChecked);
+                    if (newValue) {
+                      context.setMatchNumber(`${context.matchNumber}R`);
+                    } else {
+                      context.setMatchNumber(
+                        `${context.matchNumber.substring(
+                          0,
+                          context.matchNumber.length - 1
+                        )}`
+                      );
+                    }
+                  }}
+                />
+                <FormLabel htmlFor="replay" className="pl-6 !text-3xl">
+                  {" "}
+                  Is Replay?
+                </FormLabel>
+              </div>
               <FormMessage />
             </FormItem>
           )}

--- a/src/app/scout/[eventCode]/components/common/match-selection-form.tsx
+++ b/src/app/scout/[eventCode]/components/common/match-selection-form.tsx
@@ -36,9 +36,18 @@ export default function MatchSelectionForm({
 }: {
   setTeamSelectedEnabled: (value: boolean) => void;
 }) {
-  const [isMatchSelectionOpen, setIsMatchSelectionOpen] = useState(false);
-  const [isReplayChecked, setIsReplayChecked] = useState(false);
   const context = useContext(ScoutDataContext);
+  const [isMatchSelectionOpen, setIsMatchSelectionOpen] = useState(false);
+  const [isReplayChecked, setIsReplayChecked] = useState(
+    context.matchNumber.includes(`R`)
+  );
+  const [matchDropdownValue, setMatchDropdownValue] = useState(() => {
+    const matches = context.matchNumber.match(/\d+/g);
+    if (matches && matches.length > 0) {
+      return `Qualification ${matches[0]}`;
+    }
+    return "";
+  });
 
   const matchSelectionSchema = z.object({
     matchNumber: z
@@ -88,12 +97,18 @@ export default function MatchSelectionForm({
                       variant={"outline"}
                       className="flex flex-row justify-between h-16 text-xl"
                     >
-                      {field.value ? `Match ${field.value}` : "Select Match"}
+                      {matchDropdownValue !== ""
+                        ? matchDropdownValue
+                        : "Select Match"}
                       <ChevronDownIcon className="!size-6" />
                     </Button>
                   </PopoverTrigger>
                   <PopoverContent sideOffset={-64}>
-                    <Command className="w-94">
+                    <Command
+                      className="w-94"
+                      value={matchDropdownValue}
+                      onValueChange={setMatchDropdownValue}
+                    >
                       <CommandInput
                         placeholder="Search Match"
                         className="h-16 text-xl"
@@ -115,6 +130,7 @@ export default function MatchSelectionForm({
                                 setIsReplayChecked(false);
 
                                 context.setCurrentMatch(match);
+                                context.setTeamToScout("");
                               }}
                             >
                               {`Qualification ${match.matchNumber}`}
@@ -126,7 +142,7 @@ export default function MatchSelectionForm({
                   </PopoverContent>
                 </Popover>
               </FormControl>
-              <div className="flex flex-row items-center">
+              <div className="flex flex-row items-center pt-8">
                 <Checkbox
                   className="size-12 "
                   id="replay"

--- a/src/app/scout/[eventCode]/components/match-selection-screen.tsx
+++ b/src/app/scout/[eventCode]/components/match-selection-screen.tsx
@@ -2,13 +2,15 @@
 
 import PageHeading from "~/components/common/page-heading";
 import { Button } from "~/components/ui/button";
-import MatchSelectionForm from "./match-selection-form";
-import { useState } from "react";
-import {MoveRightIcon } from "lucide-react";
+import MatchSelectionForm from "./common/match-selection-form";
+import { useContext, useState } from "react";
+import { MoveRightIcon } from "lucide-react";
+import { ScoutDataContext } from "../context";
 
-export default function ManavPage() {
-  const [teamSelected, setTeamSelected] = useState("");
+export default function MatchSelectionScreen() {
   const [isTeamSelectedEnabled, setTeamSelectedEnabled] = useState(false);
+  const context = useContext(ScoutDataContext);
+  console.log(context.currentMatch);
   return (
     <>
       {/* Match selection */}
@@ -25,7 +27,12 @@ export default function ManavPage() {
                 variant={"blueTeam"}
                 size={"team"}
                 id="blueOne"
-                onClick={() => setTeamSelected("1114 Simbotics")}
+                onClick={() => {
+                  const team = context?.currentMatch?.teams.find(
+                    (team) => team.station === "Blue1"
+                  );
+                  context.setTeamToScout(team?.teamNumber);
+                }}
                 disabled={!isTeamSelectedEnabled}
               >
                 Blue 1
@@ -34,7 +41,12 @@ export default function ManavPage() {
                 variant={"blueTeam"}
                 size={"team"}
                 id="blueTwo"
-                onClick={() => setTeamSelected("2056 Shazzy's team")}
+                onClick={() => {
+                  const team = context?.currentMatch?.teams.find(
+                    (team) => team.station === "Blue2"
+                  );
+                  context.setTeamToScout(team?.teamNumber);
+                }}
                 disabled={!isTeamSelectedEnabled}
               >
                 Blue 2
@@ -43,7 +55,12 @@ export default function ManavPage() {
                 variant={"blueTeam"}
                 size={"team"}
                 id="blueThree"
-                onClick={() => setTeamSelected("1285 The Biggest birds")}
+                onClick={() => {
+                  const team = context?.currentMatch?.teams.find(
+                    (team) => team.station === "Blue3"
+                  );
+                  context.setTeamToScout(team?.teamNumber);
+                }}
                 disabled={!isTeamSelectedEnabled}
               >
                 Blue 3
@@ -54,7 +71,12 @@ export default function ManavPage() {
                 variant={"redTeam"}
                 size={"team"}
                 id="redOne"
-                onClick={() => setTeamSelected("5406 Celt-X")}
+                onClick={() => {
+                  const team = context?.currentMatch?.teams.find(
+                    (team) => team.station === "Red1"
+                  );
+                  context.setTeamToScout(team?.teamNumber);
+                }}
                 disabled={!isTeamSelectedEnabled}
               >
                 Red 1
@@ -63,7 +85,12 @@ export default function ManavPage() {
                 variant={"redTeam"}
                 size={"team"}
                 id="redTwo"
-                onClick={() => setTeamSelected("1241 Theory6")}
+                onClick={() => {
+                  const team = context?.currentMatch?.teams.find(
+                    (team) => team.station === "Red2"
+                  );
+                  context.setTeamToScout(team?.teamNumber);
+                }}
                 disabled={!isTeamSelectedEnabled}
               >
                 Red 2
@@ -72,7 +99,12 @@ export default function ManavPage() {
                 variant={"redTeam"}
                 size={"team"}
                 id="redThree"
-                onClick={() => setTeamSelected("987 Highrollers")}
+                onClick={() => {
+                  const team = context?.currentMatch?.teams.find(
+                    (team) => team.station === "Red3"
+                  );
+                  context.setTeamToScout(team?.teamNumber);
+                }}
                 disabled={!isTeamSelectedEnabled}
               >
                 Red 3
@@ -91,12 +123,12 @@ export default function ManavPage() {
       </div>
 
       <div className="flex flex-row mt-16 justify-between items-center">
-        <p className="text-2xl">{`Team Scouted: ${teamSelected}`}</p>
+        <p className="text-2xl">{`Team Scouted: ${context.teamToScout}`}</p>
         <Button
           className="!w-64"
           variant={"proceed"}
           size={"proceed"}
-          disabled={teamSelected === ""}
+          disabled={context.teamToScout === undefined}
         >
           Continue
           <MoveRightIcon> </MoveRightIcon>

--- a/src/app/scout/[eventCode]/components/match-selection-screen.tsx
+++ b/src/app/scout/[eventCode]/components/match-selection-screen.tsx
@@ -4,13 +4,30 @@ import PageHeading from "~/components/common/page-heading";
 import { Button } from "~/components/ui/button";
 import MatchSelectionForm from "./common/match-selection-form";
 import { useContext, useState } from "react";
-import { MoveRightIcon } from "lucide-react";
-import { ScoutDataContext } from "../context";
+import { ScoutDataContext, ScoutScreenContext } from "../context";
+import { cn } from "~/lib/utils";
+import ContinueButton from "./common/continue-button";
 
 export default function MatchSelectionScreen() {
-  const [isTeamSelectedEnabled, setTeamSelectedEnabled] = useState(false);
   const context = useContext(ScoutDataContext);
-  console.log(context.currentMatch);
+  const [isTeamSelectedEnabled, setTeamSelectedEnabled] = useState(
+    !!context.teamToScout
+  );
+  const [positionSelected, setPositionSelected] = useState(() => {
+    const currentMatch = context.matchNumber.match(/\d+/g);
+    let value = "";
+    if (currentMatch && currentMatch.length > 0) {
+      const currentMatchIndex = parseInt(currentMatch[0]) - 1;
+      context.matchSchedule[currentMatchIndex].teams.map((team) => {
+        if (team.teamNumber === context.teamToScout) {
+          value = team.station;
+        }
+      });
+    }
+    return value;
+  });
+  const screenContext = useContext(ScoutScreenContext);
+  console.log(positionSelected);
   return (
     <>
       {/* Match selection */}
@@ -18,13 +35,24 @@ export default function MatchSelectionScreen() {
 
       <div className="flex justify-between items-center gap-4">
         <MatchSelectionForm setTeamSelectedEnabled={setTeamSelectedEnabled} />
-
+        <div className="flex flex-row mt-16 justify-between items-center">
+          {context.teamToScout && (
+            <div className="flex flex-col justify-between">
+              <p className="text-4xl">{`Team Scouted `}</p>
+              <p className="text-4xl">{`${context.teamToScout}`}</p>
+            </div>
+          )}
+        </div>
         <div className="flex flex-col items-center justify-end gap-2">
           <p className="text-2xl font-bold self-start">Select Position</p>
           <div className="flex flex-row justify-end gap-2">
             <div className="flex flex-col space-y-3">
               <Button
                 variant={"blueTeam"}
+                className={cn(
+                  positionSelected === "Blue1" &&
+                    "dark:ring-2 ring-yellow-400  ring-offset-4"
+                )}
                 size={"team"}
                 id="blueOne"
                 onClick={() => {
@@ -32,12 +60,18 @@ export default function MatchSelectionScreen() {
                     (team) => team.station === "Blue1"
                   );
                   context.setTeamToScout(team?.teamNumber);
+                  context.setAllianceColour("blue");
+                  setPositionSelected("Blue1");
                 }}
                 disabled={!isTeamSelectedEnabled}
               >
                 Blue 1
               </Button>
               <Button
+                className={cn(
+                  positionSelected === "Blue2" &&
+                    "dark:ring-2 ring-yellow-400  ring-offset-4"
+                )}
                 variant={"blueTeam"}
                 size={"team"}
                 id="blueTwo"
@@ -46,12 +80,18 @@ export default function MatchSelectionScreen() {
                     (team) => team.station === "Blue2"
                   );
                   context.setTeamToScout(team?.teamNumber);
+                  context.setAllianceColour("blue");
+                  setPositionSelected("Blue2");
                 }}
                 disabled={!isTeamSelectedEnabled}
               >
                 Blue 2
               </Button>
               <Button
+                className={cn(
+                  positionSelected === "Blue3" &&
+                    "dark:ring-2 ring-yellow-400  ring-offset-4"
+                )}
                 variant={"blueTeam"}
                 size={"team"}
                 id="blueThree"
@@ -60,6 +100,8 @@ export default function MatchSelectionScreen() {
                     (team) => team.station === "Blue3"
                   );
                   context.setTeamToScout(team?.teamNumber);
+                  context.setAllianceColour("blue");
+                  setPositionSelected("Blue3");
                 }}
                 disabled={!isTeamSelectedEnabled}
               >
@@ -68,6 +110,10 @@ export default function MatchSelectionScreen() {
             </div>
             <div className="flex flex-col space-y-3">
               <Button
+                className={cn(
+                  positionSelected === "Red1" &&
+                    "dark:ring-2 ring-yellow-400  ring-offset-4"
+                )}
                 variant={"redTeam"}
                 size={"team"}
                 id="redOne"
@@ -76,12 +122,18 @@ export default function MatchSelectionScreen() {
                     (team) => team.station === "Red1"
                   );
                   context.setTeamToScout(team?.teamNumber);
+                  context.setAllianceColour("red");
+                  setPositionSelected("Red1");
                 }}
                 disabled={!isTeamSelectedEnabled}
               >
                 Red 1
               </Button>
               <Button
+                className={cn(
+                  positionSelected === "Red2" &&
+                    "dark:ring-2 ring-yellow-400  ring-offset-4"
+                )}
                 variant={"redTeam"}
                 size={"team"}
                 id="redTwo"
@@ -89,13 +141,20 @@ export default function MatchSelectionScreen() {
                   const team = context?.currentMatch?.teams.find(
                     (team) => team.station === "Red2"
                   );
+
                   context.setTeamToScout(team?.teamNumber);
+                  context.setAllianceColour("red");
+                  setPositionSelected("Red2");
                 }}
                 disabled={!isTeamSelectedEnabled}
               >
                 Red 2
               </Button>
               <Button
+                className={cn(
+                  positionSelected === "Red3" &&
+                    "dark:ring-2 ring-yellow-400  ring-offset-4"
+                )}
                 variant={"redTeam"}
                 size={"team"}
                 id="redThree"
@@ -104,6 +163,8 @@ export default function MatchSelectionScreen() {
                     (team) => team.station === "Red3"
                   );
                   context.setTeamToScout(team?.teamNumber);
+                  context.setAllianceColour("red");
+                  setPositionSelected("Red3");
                 }}
                 disabled={!isTeamSelectedEnabled}
               >
@@ -113,26 +174,34 @@ export default function MatchSelectionScreen() {
           </div>
           <div className="w-full">
             <Button
-              className="w-full h-16 mt-1 !bg-teal-500 font-bold"
+              className={cn(
+                "w-full h-16 mt-1 !bg-teal-500 font-bold",
+                positionSelected === "Human Players" &&
+                  "dark:ring-2 ring-yellow-400  ring-offset-4"
+              )}
               disabled={!isTeamSelectedEnabled}
+              onClick={() => {
+                context.setIsAlternateScout(true);
+                context.setTeamToScout("Human Players");
+                setPositionSelected("Human Players");
+              }}
             >
               Ball Scout
             </Button>
           </div>
         </div>
       </div>
-
-      <div className="flex flex-row mt-16 justify-between items-center">
-        <p className="text-2xl">{`Team Scouted: ${context.teamToScout}`}</p>
-        <Button
-          className="!w-64"
-          variant={"proceed"}
-          size={"proceed"}
-          disabled={context.teamToScout === undefined}
-        >
-          Continue
-          <MoveRightIcon> </MoveRightIcon>
-        </Button>
+      <div className="flex flex-row-reverse mt-16 justify-between items-center">
+        <ContinueButton
+          disabled={context.teamToScout === ""}
+          onClick={() => {
+            if (context.teamToScout === "Human Players") {
+              screenContext.goToScreen("alternate-scout-setup");
+            } else {
+              screenContext.nextScreen();
+            }
+          }}
+        />
       </div>
     </>
   );

--- a/src/app/scout/[eventCode]/components/match-selection-screen.tsx
+++ b/src/app/scout/[eventCode]/components/match-selection-screen.tsx
@@ -193,7 +193,7 @@ export default function MatchSelectionScreen() {
       </div>
       <div className="flex flex-row-reverse mt-16 justify-between items-center">
         <ContinueButton
-          disabled={context.teamToScout === ""}
+          disabled={!context.teamToScout}
           onClick={() => {
             if (context.teamToScout === "Human Players") {
               screenContext.goToScreen("alternate-scout-setup");

--- a/src/app/scout/[eventCode]/components/starting-position-screen.tsx
+++ b/src/app/scout/[eventCode]/components/starting-position-screen.tsx
@@ -8,7 +8,7 @@ import ContinueButton from "./common/continue-button";
 import { Checkbox } from "~/components/ui/checkbox";
 import FieldImage from "./common/field-image";
 import { useContext, useState } from "react";
-import { ScoutDataContext } from "../context";
+import { ScoutDataContext, ScoutScreenContext } from "../context";
 import {
   FIELD_ORIENTATIONS,
   LOCAL_STORAGE_KEYS,
@@ -19,6 +19,7 @@ import { getFlexDirection } from "../utils";
 
 export default function StartingPositionScreen() {
   const context = useContext(ScoutDataContext);
+  const screenContext = useContext(ScoutScreenContext);
   const toggleFieldOrientation = () => {
     const newOrientation =
       context.uiOrientation === FIELD_ORIENTATIONS.DEFAULT
@@ -169,8 +170,9 @@ export default function StartingPositionScreen() {
       </FieldImage>
       <div className="flex flex-row">
         <div className="flex justify-between w-full">
-          <BackButton />
+          <BackButton onClick={() => screenContext.prevScreen()} />
           <ContinueButton
+            onClick={() => screenContext.nextScreen()}
             disabled={
               isSaved === false || context.startingPosition.position === ""
             }

--- a/src/app/scout/[eventCode]/context/data-context.tsx
+++ b/src/app/scout/[eventCode]/context/data-context.tsx
@@ -41,6 +41,8 @@ interface ScoutDataContextType {
   setAlternateScoutData?: (alternateScoutData: AlternateScoutData) => void;
   matchSchedule: MatchScheduleType[];
   setMatchSchedule: (matchSchedule: MatchScheduleType[]) => void;
+  currentMatch: MatchScheduleType | undefined;
+  setCurrentMatch: (match: MatchScheduleType) => void;
   fieldImages: FieldImages[] | undefined;
   matchNumber: string;
   setMatchNumber: (matchNumber: string) => void;

--- a/src/app/scout/[eventCode]/context/data-context.tsx
+++ b/src/app/scout/[eventCode]/context/data-context.tsx
@@ -46,8 +46,8 @@ interface ScoutDataContextType {
   fieldImages: FieldImages[] | undefined;
   matchNumber: string;
   setMatchNumber: (matchNumber: string) => void;
-  teamToScout: number | undefined;
-  setTeamToScout: (teamToScout: number | undefined) => void;
+  teamToScout: number | string | undefined;
+  setTeamToScout: (teamToScout: number | string | undefined) => void;
   allianceColour: string;
   setAllianceColour: (allianceColour: string) => void;
   uiOrientation: string;

--- a/src/app/scout/[eventCode]/page.tsx
+++ b/src/app/scout/[eventCode]/page.tsx
@@ -31,6 +31,7 @@ import {
   GAME_PIECES,
   LOCATIONS,
 } from "~/app/scout/[eventCode]/constants";
+import MatchSelectionScreen from "./components/match-selection-screen";
 
 const ScoutPage = () => {
   const { eventCode } = useParams<{ eventCode: string }>();
@@ -54,7 +55,7 @@ const ScoutPage = () => {
   // TODO: Update the components of each screen to be the actual screen once the dev for it is completed
   const screens = [
     {
-      component: <div>Match selection screen</div>,
+      component: <MatchSelectionScreen />,
       name: SCREEN_NAMES.MATCH_SELECTION,
       canGoBack: false,
     },
@@ -103,12 +104,14 @@ const ScoutPage = () => {
   const [undoOccurred, setUndoOccurred] = useState(false);
   const [wasDefended, setWasDefended] = useState(false);
   const [matchSchedule, setMatchSchedule] = useState<MatchScheduleType[]>([]);
+  const [currentMatch, setCurrentMatch] = useState<MatchScheduleType>();
   const [currentScreenIndex, setCurrentScreenIndex] = useState(0);
   const [matchNumber, setMatchNumber] = useState("");
   const [teamToScout, setTeamToScout] = useState<number | undefined>();
   const [allianceColour, setAllianceColour] = useState("");
   const [uiOrientation, setUiOrientation] = useState(
-    localStorage.getItem(LOCAL_STORAGE_KEYS.UI_ORIENTATION) ||
+    (typeof window !== "undefined" &&
+      localStorage.getItem(LOCAL_STORAGE_KEYS.UI_ORIENTATION)) ||
       FIELD_ORIENTATIONS.DEFAULT
   );
   const [scouterDetails, setScouterDetails] = useState({
@@ -167,6 +170,7 @@ const ScoutPage = () => {
 
   const { data: matchScheduleData } = useQuery({
     enabled: !!eventCode,
+    // enabled: false,
     queryKey: ["matchSchedule", eventCode],
     queryFn: async (): Promise<MatchScheduleType[]> =>
       fetchMatchScheduleByYearAndEventCode(
@@ -235,6 +239,8 @@ const ScoutPage = () => {
           setAlternateScoutData,
           matchSchedule,
           setMatchSchedule,
+          currentMatch,
+          setCurrentMatch,
           matchNumber,
           setMatchNumber,
           teamToScout,

--- a/src/server/http/frc-events/index.ts
+++ b/src/server/http/frc-events/index.ts
@@ -8,7 +8,7 @@ const authorizationCredential = btoa(
 
 const FrcEventsInstance = axios.create({
   baseURL: "https://frc-api.firstinspires.org/v3.0",
-  timeout: 5000,
+  // timeout: 5000,
   headers: {
     Authorization: `Basic ${authorizationCredential}`,
   },


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/fb79de40-3130-4787-b0b4-da58fada0adb)
Match selection screen when loaded, all buttons except for Select Team dropdown are disabled.
![image](https://github.com/user-attachments/assets/c3b40636-d2f2-4d50-8cdc-1c0b4ccf4046)
Match is selected and all buttons are enabled except for continue
![image](https://github.com/user-attachments/assets/e0f484d5-dfd5-4532-a299-0ca0387d8e4e)
Replay matches are identified accordingly
![image](https://github.com/user-attachments/assets/e2512c42-23f0-47bb-87a0-8f89506984df)
Once Team is selected the colour of the Team changes accordingly, the continue button is enabled and the team number that was selected appears in the center.
![image](https://github.com/user-attachments/assets/a70b1d65-29a3-4214-94e9-8a3a65c4f67d)
The same is true if a human player is selected
![image](https://github.com/user-attachments/assets/a842f829-d768-4091-bb38-9a7c67219a65)
State is saved when moving from screen to screen
![image](https://github.com/user-attachments/assets/3119af56-1a82-4cc7-a986-511080eaca4e)
