### PR TITLE
Endgame tweaks + brownout 

### DIFF
--- a/src/app/scout/[eventCode]/components/common/match-scouting-layout.tsx
+++ b/src/app/scout/[eventCode]/components/common/match-scouting-layout.tsx
@@ -15,9 +15,9 @@ import ScoutActionButton from "./scout-action-button";
 import { toast } from "sonner";
 
 export const MatchScoutingLayout = ({
-  isDisabled,
+  isDisabled = false,
 }: {
-  isDisabled: boolean;
+  isDisabled?: boolean;
 }) => {
   const context = useContext(ScoutDataContext);
   const hasCoral = context.gamePieceState[0].count > 0;

--- a/src/app/scout/[eventCode]/components/common/scout-action-button.tsx
+++ b/src/app/scout/[eventCode]/components/common/scout-action-button.tsx
@@ -17,6 +17,7 @@ const ScoutActionButton = ({
   label,
   onClick,
   disabled,
+  shouldBeHidden = true,
 }: {
   actionName: string;
   gamePiece?: string;
@@ -26,6 +27,7 @@ const ScoutActionButton = ({
   label: string;
   onClick?: () => void;
   disabled?: boolean;
+  shouldBeHidden?: boolean;
 }) => {
   const scoutDataContext = useContext(ScoutDataContext);
   const isBlueAlliance =
@@ -67,8 +69,11 @@ const ScoutActionButton = ({
       className={cn(
         "text-white font-bold",
         isBlueAlliance ? "bg-blue-300/50" : "bg-red-300/50",
-        scoutDataContext.isDefending || scoutDataContext.isAutoStopped
-          ? "disabled:opacity-10"
+        scoutDataContext.isDefending ||
+          scoutDataContext.isAutoStopped ||
+          scoutDataContext.isBrownedOut ||
+          !shouldBeHidden
+          ? "disabled:opacity-20"
           : "disabled:opacity-0",
         className
       )}

--- a/src/app/scout/[eventCode]/components/endgame-screen.tsx
+++ b/src/app/scout/[eventCode]/components/endgame-screen.tsx
@@ -36,7 +36,6 @@ export default function EndgameScreen() {
     setActionDone(context.previousEndgameAction.actionDone);
   }, [context.previousEndgameAction]);
 
-
   function checkActionButtonDisabled() {
     let disability = false;
     if (!positionSelected || actionDone) {
@@ -48,14 +47,28 @@ export default function EndgameScreen() {
 
   const [screenDisabled, setScreenDisabled] = useState(false);
   const [climbStarted, setClimbStarted] = useState(false);
-  const [brownOutLabel, setBrownOutLabel] = useState("BROWNOUT")
-  const [button1Style, setButton1Style] = useState("mb-1 h-16 w-40 font-bold text-xl bg-pink-600")
-  const [button2Style, setButton2Style] = useState("mb-1 h-16 w-40 font-bold text-xl bg-pink-600")
-  const [button3Style, setButton3Style] = useState("mb-1 h-16 w-40 font-bold text-xl bg-blue-500")
-  const [button4Style, setButton4Style] = useState("mb-1 h-16 w-40 font-bold text-xl bg-blue-500")
-  const [popoverButton1Style, setPopoverButton1Style] = useState("mb-1 h-16 w-40 font-bold text-xl !bg-pink-600 !text-white")
-  const [popoverButton2Style, setPopoverButton2Style] = useState("mb-1 h-16 w-40 font-bold text-xl !bg-pink-600 !text-white")
-  const [startClimbButtonStyle, setStartClimbButtonStyle] = useState("mb-1 h-16 w-40 font-bold text-xl !bg-green-700 !text-white")
+  const [brownOutLabel, setBrownOutLabel] = useState("BROWNOUT");
+  const [button1Style, setButton1Style] = useState(
+    "mb-1 h-16 w-40 font-bold text-xl bg-pink-600"
+  );
+  const [button2Style, setButton2Style] = useState(
+    "mb-1 h-16 w-40 font-bold text-xl bg-pink-600"
+  );
+  const [button3Style, setButton3Style] = useState(
+    "mb-1 h-16 w-40 font-bold text-xl bg-blue-500"
+  );
+  const [button4Style, setButton4Style] = useState(
+    "mb-1 h-16 w-40 font-bold text-xl bg-blue-500"
+  );
+  const [popoverButton1Style, setPopoverButton1Style] = useState(
+    "mb-1 h-16 w-40 font-bold text-xl !bg-pink-600 !text-white"
+  );
+  const [popoverButton2Style, setPopoverButton2Style] = useState(
+    "mb-1 h-16 w-40 font-bold text-xl !bg-pink-600 !text-white"
+  );
+  const [startClimbButtonStyle, setStartClimbButtonStyle] = useState(
+    "mb-1 h-16 w-40 font-bold text-xl !bg-green-700 !text-white"
+  );
   return (
     <>
       <div className="flex flex-row">
@@ -101,12 +114,23 @@ export default function EndgameScreen() {
                 });
                 toast.error("Robot climbed shallow cage!");
                 setCurrentAction("Successfully Climbed Shallow Cage");
-                setClimbStarted(false)
-                setButton1Style("mb-1 h-16 w-40 font-bold text-xl bg-white text-black")
-                setTimeout(() => setButton1Style("mb-1 h-16 w-40 font-bold text-xl bg-pink-600"),500)
+                setClimbStarted(false);
+                setButton1Style(
+                  "mb-1 h-16 w-40 font-bold text-xl bg-white text-black"
+                );
+                setTimeout(
+                  () =>
+                    setButton1Style(
+                      "mb-1 h-16 w-40 font-bold text-xl bg-pink-600"
+                    ),
+                  500
+                );
               }}
-
-              disabled={checkActionButtonDisabled() || screenDisabled || climbStarted === false}
+              disabled={
+                checkActionButtonDisabled() ||
+                screenDisabled ||
+                climbStarted === false
+              }
               label="Shallow Hang"
             />
             <ScoutActionButton
@@ -122,14 +146,26 @@ export default function EndgameScreen() {
                   positionSelected: hangPositionSelected,
                   actionMessage: "Successfully Climbed Deep",
                 });
-           
+
                 toast.error("Robot climbed deep cage!");
                 setCurrentAction("Successfully Climbed Deep Cage");
-                setClimbStarted(false)
-                setButton2Style("mb-1 h-16 w-40 font-bold text-xl bg-white text-black")
-                setTimeout(() => setButton2Style("mb-1 h-16 w-40 font-bold text-xl bg-pink-600"),500)
+                setClimbStarted(false);
+                setButton2Style(
+                  "mb-1 h-16 w-40 font-bold text-xl bg-white text-black"
+                );
+                setTimeout(
+                  () =>
+                    setButton2Style(
+                      "mb-1 h-16 w-40 font-bold text-xl bg-pink-600"
+                    ),
+                  500
+                );
               }}
-              disabled={checkActionButtonDisabled() || screenDisabled || climbStarted === false}
+              disabled={
+                checkActionButtonDisabled() ||
+                screenDisabled ||
+                climbStarted === false
+              }
               label="Deep Hang"
             />
 
@@ -146,25 +182,44 @@ export default function EndgameScreen() {
                   positionSelected: hangPositionSelected,
                   actionMessage: "Successfully Parked",
                 });
-              
+
                 toast.error("Robot parked!");
                 setCurrentAction("Successfully Parked");
-                setButton3Style("mb-1 h-16 w-40 font-bold text-xl bg-white text-black")
-                setTimeout(() => setButton3Style("mb-1 h-16 w-40 font-bold text-xl bg-blue-500"),500)
+                setButton3Style(
+                  "mb-1 h-16 w-40 font-bold text-xl bg-white text-black"
+                );
+                setTimeout(
+                  () =>
+                    setButton3Style(
+                      "mb-1 h-16 w-40 font-bold text-xl bg-blue-500"
+                    ),
+                  500
+                );
               }}
-              disabled={checkActionButtonDisabled() || screenDisabled || climbStarted}
+              disabled={
+                checkActionButtonDisabled() || screenDisabled || climbStarted
+              }
               label="Park"
             />
 
             <Popover
               open={isMatchSelectionOpen}
               onOpenChange={setIsMatchSelectionOpen}
-              
             >
-              <PopoverTrigger disabled={checkActionButtonDisabled() || screenDisabled || climbStarted === false}>
+              <PopoverTrigger
+                disabled={
+                  checkActionButtonDisabled() ||
+                  screenDisabled ||
+                  climbStarted === false
+                }
+              >
                 <Button
                   className="mb-1 h-16 w-40 font-bold text-xl !text-white !bg-pink-600 hover:dark:bg-white"
-                  disabled={checkActionButtonDisabled() || screenDisabled || climbStarted === false}
+                  disabled={
+                    checkActionButtonDisabled() ||
+                    screenDisabled ||
+                    climbStarted === false
+                  }
                 >
                   {" "}
                   Failed Attempt
@@ -187,12 +242,24 @@ export default function EndgameScreen() {
                     });
                     toast.error("Robot failed shallow climb!");
                     setCurrentAction("Shallow Climb Failed ");
-                    setTimeout(() => setIsMatchSelectionOpen(false),500)
-                    setPopoverButton1Style("mb-1 h-16 w-40 font-bold text-xl !bg-white !text-black");
-                    setTimeout(() => setPopoverButton1Style("mb-1 h-16 w-40 font-bold text-xl !bg-pink-600 !text-white"),1000);
-                    setClimbStarted(false)                                
+                    setTimeout(() => setIsMatchSelectionOpen(false), 500);
+                    setPopoverButton1Style(
+                      "mb-1 h-16 w-40 font-bold text-xl !bg-white !text-black"
+                    );
+                    setTimeout(
+                      () =>
+                        setPopoverButton1Style(
+                          "mb-1 h-16 w-40 font-bold text-xl !bg-pink-600 !text-white"
+                        ),
+                      1000
+                    );
+                    setClimbStarted(false);
                   }}
-                  disabled={checkActionButtonDisabled() || screenDisabled || climbStarted === false}
+                  disabled={
+                    checkActionButtonDisabled() ||
+                    screenDisabled ||
+                    climbStarted === false
+                  }
                   label="Shallow Hang"
                 />
 
@@ -212,12 +279,24 @@ export default function EndgameScreen() {
                     });
                     toast.error("Robot failed deep climb!");
                     setCurrentAction("Deep Climb Failed");
-                    setTimeout(() => setIsMatchSelectionOpen(false),500)
-                    setPopoverButton2Style("mb-1 h-16 w-40 font-bold text-xl !bg-white !text-black");
-                    setTimeout(() => setPopoverButton2Style("mb-1 h-16 w-40 font-bold text-xl !bg-pink-600 !text-white"),1000);
-                    setClimbStarted(false)
+                    setTimeout(() => setIsMatchSelectionOpen(false), 500);
+                    setPopoverButton2Style(
+                      "mb-1 h-16 w-40 font-bold text-xl !bg-white !text-black"
+                    );
+                    setTimeout(
+                      () =>
+                        setPopoverButton2Style(
+                          "mb-1 h-16 w-40 font-bold text-xl !bg-pink-600 !text-white"
+                        ),
+                      1000
+                    );
+                    setClimbStarted(false);
                   }}
-                  disabled={checkActionButtonDisabled() || screenDisabled || climbStarted === false}
+                  disabled={
+                    checkActionButtonDisabled() ||
+                    screenDisabled ||
+                    climbStarted === false
+                  }
                   label="Deep Hang"
                 />
               </PopoverContent>
@@ -227,7 +306,9 @@ export default function EndgameScreen() {
               gamePiece={GAME_PIECES.NOGAMEPIECE}
               location={hangPositionSelected}
               className={button4Style}
-              disabled={checkActionButtonDisabled() || screenDisabled || climbStarted}
+              disabled={
+                checkActionButtonDisabled() || screenDisabled || climbStarted
+              }
               onClick={() => {
                 setActionDone(true);
                 toast.error("Robot did not attempt endgame action!");
@@ -237,8 +318,16 @@ export default function EndgameScreen() {
                   positionSelected: hangPositionSelected,
                   actionMessage: "Endgame action skipped",
                 });
-                setButton4Style("mb-1 h-16 w-40 font-bold text-xl bg-white text-black")
-                setTimeout(() => setButton4Style("mb-1 h-16 w-40 font-bold text-xl bg-blue-600"),500)
+                setButton4Style(
+                  "mb-1 h-16 w-40 font-bold text-xl bg-white text-black"
+                );
+                setTimeout(
+                  () =>
+                    setButton4Style(
+                      "mb-1 h-16 w-40 font-bold text-xl bg-blue-600"
+                    ),
+                  500
+                );
               }}
               label="Not Attempted"
             />
@@ -250,20 +339,29 @@ export default function EndgameScreen() {
               gamePiece={GAME_PIECES.NOGAMEPIECE}
               location={hangPositionSelected}
               className={startClimbButtonStyle}
-              disabled={checkActionButtonDisabled() || climbStarted === true || screenDisabled}
+              disabled={
+                checkActionButtonDisabled() ||
+                climbStarted === true ||
+                screenDisabled
+              }
               onClick={() => {
                 toast.error("Climb started!");
                 setCurrentAction("Started Climb Attempt");
-                setStartClimbButtonStyle("mb-1 h-16 w-40 font-bold text-xl bg-white text-black")
-                setTimeout(() => setStartClimbButtonStyle("mb-1 h-16 w-40 font-bold text-xl bg-green-700"),500)
-                setClimbStarted(true)
+                setStartClimbButtonStyle(
+                  "mb-1 h-16 w-40 font-bold text-xl bg-white text-black"
+                );
+                setTimeout(
+                  () =>
+                    setStartClimbButtonStyle(
+                      "mb-1 h-16 w-40 font-bold text-xl bg-green-700"
+                    ),
+                  500
+                );
+                setClimbStarted(true);
               }}
               label="Start Climb"
             />
           </div>
-
-
-
 
           <div
             className={cn(
@@ -276,13 +374,12 @@ export default function EndgameScreen() {
               className={cn(
                 "h-12 w-40 font-bold text-xl opacity-90 !bg-cyan-100",
                 hangPositionSelected === LOCATIONS.BARGE.OUTER &&
-                "dark:ring-2 ring-yellow-400  ring-offset-4"
+                  "dark:ring-2 ring-yellow-400  ring-offset-4"
               )}
               onClick={() => {
                 setPositionSelected(true);
                 setHangPositionSelected(LOCATIONS.BARGE.OUTER);
               }}
-
               disabled={screenDisabled}
             >
               Far Cage
@@ -291,7 +388,7 @@ export default function EndgameScreen() {
               className={cn(
                 " h-12 w-40  font-bold text-xl opacity-90 !bg-cyan-100",
                 hangPositionSelected === LOCATIONS.BARGE.MIDDLE &&
-                "dark:ring-2 ring-yellow-400  ring-offset-4"
+                  "dark:ring-2 ring-yellow-400  ring-offset-4"
               )}
               onClick={() => {
                 setHangPositionSelected(LOCATIONS.BARGE.MIDDLE);
@@ -305,7 +402,7 @@ export default function EndgameScreen() {
               className={cn(
                 " mb-1 h-12 w-40  font-bold text-xl opacity-90 !bg-cyan-100",
                 hangPositionSelected === LOCATIONS.BARGE.INNER &&
-                "dark:ring-2 ring-yellow-400  ring-offset-4"
+                  "dark:ring-2 ring-yellow-400  ring-offset-4"
               )}
               onClick={() => {
                 setPositionSelected(true);
@@ -332,20 +429,16 @@ export default function EndgameScreen() {
           location="null"
           label={brownOutLabel}
           onClick={() => {
-            if (screenDisabled == false){
+            if (screenDisabled == false) {
               setScreenDisabled(true);
               toast.error("Robot has stopped. Screen disabled!");
-              setBrownOutLabel("ROBOT RESTARTED")
-
-            }
-            else{
-              setScreenDisabled(false)
+              setBrownOutLabel("ROBOT RESTARTED");
+            } else {
+              setScreenDisabled(false);
               toast.error("Robot has restarted. Screen enabled!");
-              setBrownOutLabel("BROWNOUT")
-            } 
-    
+              setBrownOutLabel("BROWNOUT");
+            }
           }}
-
         />
 
         <ContinueButton

--- a/src/app/scout/[eventCode]/components/endgame-screen.tsx
+++ b/src/app/scout/[eventCode]/components/endgame-screen.tsx
@@ -21,13 +21,14 @@ import ContinueButton from "./common/continue-button";
 import BackButton from "./common/back-button";
 import UndoActionButton from "./common/undo-action-button";
 import { getFlexDirection } from "../utils";
-
+import { toast } from "sonner";
 export default function EndgameScreen() {
   const context = useContext(ScoutDataContext);
   const screenContext = useContext(ScoutScreenContext);
   const [hangPositionSelected, setHangPositionSelected] = useState<string>("");
   const [currentAction, setCurrentAction] = useState<string>("");
   const [isMatchSelectionOpen, setIsMatchSelectionOpen] = useState(false);
+<<<<<<< HEAD
   const [actionDone, setActionDone] = useState(false);
   const [positionSelected, setPositionSelected] = useState(false);
   useEffect(() => {
@@ -44,6 +45,18 @@ export default function EndgameScreen() {
     return disability;
   }
 
+=======
+  const [screenDisabled, setScreenDisabled] = useState(false);
+  const [climbStarted, setClimbStarted] = useState(false);
+  const [brownOutLabel, setBrownOutLabel] = useState("BROWNOUT")
+  const [button1Style, setButton1Style] = useState("mb-1 h-16 w-40 font-bold text-xl bg-pink-600")
+  const [button2Style, setButton2Style] = useState("mb-1 h-16 w-40 font-bold text-xl bg-pink-600")
+  const [button3Style, setButton3Style] = useState("mb-1 h-16 w-40 font-bold text-xl bg-blue-500")
+  const [button4Style, setButton4Style] = useState("mb-1 h-16 w-40 font-bold text-xl bg-blue-500")
+  const [popoverButton1Style, setPopoverButton1Style] = useState("mb-1 h-16 w-40 font-bold text-xl !bg-pink-600 !text-white")
+  const [popoverButton2Style, setPopoverButton2Style] = useState("mb-1 h-16 w-40 font-bold text-xl !bg-pink-600 !text-white")
+  const [startClimbButtonStyle, setStartClimbButtonStyle] = useState("mb-1 h-16 w-40 font-bold text-xl !bg-green-700 !text-white")
+>>>>>>> 59282ce (final commit before rebase hopefully - added brownout buttons, better button feedback for endgame screen, as well as reworking how recording climbs work w the start climb button)
   return (
     <>
       <div className="flex flex-row">
@@ -63,7 +76,7 @@ export default function EndgameScreen() {
             className="text-xl bg-red-600 h-16 w-40"
           />
         </div>
-        <p className="text-2xl font-bold mt-4 ml-[5rem]">{`Action Selected: ${currentAction} `}</p>
+        <p className="text-2xl font-bold mt-4 ml-[5rem]">{`Most Recent: ${currentAction} `}</p>
       </div>
 
       <FieldImage imageSize="100%" fieldSize="half">
@@ -88,15 +101,29 @@ export default function EndgameScreen() {
               actionName={ACTION_NAMES.CLIMB.SUCCESS}
               gamePiece={GAME_PIECES.CAGE.SHALLOW}
               location={hangPositionSelected}
+<<<<<<< HEAD
               disabled={checkActionButtonDisabled()}
+=======
+              className={button1Style}
+              onClick={() => {
+                toast.error("Robot climbed shallow cage!");
+                setCurrentAction("Successfully Climbed Shallow Cage");
+                setClimbStarted(false)
+                setButton1Style("mb-1 h-16 w-40 font-bold text-xl bg-white text-black")
+                setTimeout(() => setButton1Style("mb-1 h-16 w-40 font-bold text-xl bg-pink-600"),500)
+              }}
+
+              disabled={hangPositionSelected === "" || screenDisabled || climbStarted === false}
+>>>>>>> 59282ce (final commit before rebase hopefully - added brownout buttons, better button feedback for endgame screen, as well as reworking how recording climbs work w the start climb button)
               label="Shallow Hang"
             />
             <ScoutActionButton
               actionName={ACTION_NAMES.CLIMB.SUCCESS}
               gamePiece={GAME_PIECES.CAGE.DEEP}
               location={hangPositionSelected}
-              className=" mb-1 h-16 w-40 font-bold text-xl bg-pink-600"
+              className={button2Style}
               onClick={() => {
+<<<<<<< HEAD
                 setActionDone(true);
                 setCurrentAction("Successfully Climbed Deep");
                 context.setPreviousEndgameAction({
@@ -106,6 +133,15 @@ export default function EndgameScreen() {
                 });
               }}
               disabled={checkActionButtonDisabled()}
+=======
+                toast.error("Robot climbed deep cage!");
+                setCurrentAction("Successfully Climbed Deep Cage");
+                setClimbStarted(false)
+                setButton2Style("mb-1 h-16 w-40 font-bold text-xl bg-white text-black")
+                setTimeout(() => setButton2Style("mb-1 h-16 w-40 font-bold text-xl bg-pink-600"),500)
+              }}
+              disabled={hangPositionSelected === "" || screenDisabled || climbStarted === false}
+>>>>>>> 59282ce (final commit before rebase hopefully - added brownout buttons, better button feedback for endgame screen, as well as reworking how recording climbs work w the start climb button)
               label="Deep Hang"
             />
 
@@ -113,8 +149,9 @@ export default function EndgameScreen() {
               actionName={ACTION_NAMES.PARK}
               gamePiece={GAME_PIECES.NOGAMEPIECE}
               location={hangPositionSelected}
-              className=" mb-1 h-16 w-40 font-bold text-xl bg-pink-600"
+              className={button3Style}
               onClick={() => {
+<<<<<<< HEAD
                 setActionDone(true);
                 setCurrentAction("Successfully Parked");
                 context.setPreviousEndgameAction({
@@ -124,30 +161,46 @@ export default function EndgameScreen() {
                 });
               }}
               disabled={checkActionButtonDisabled()}
+=======
+                toast.error("Robot parked!");
+                setCurrentAction("Successfully Parked");
+                setButton3Style("mb-1 h-16 w-40 font-bold text-xl bg-white text-black")
+                setTimeout(() => setButton3Style("mb-1 h-16 w-40 font-bold text-xl bg-blue-500"),500)
+              }}
+              disabled={hangPositionSelected === "" || screenDisabled || climbStarted}
+>>>>>>> 59282ce (final commit before rebase hopefully - added brownout buttons, better button feedback for endgame screen, as well as reworking how recording climbs work w the start climb button)
               label="Park"
             />
 
             <Popover
               open={isMatchSelectionOpen}
               onOpenChange={setIsMatchSelectionOpen}
+              
             >
+<<<<<<< HEAD
               <PopoverTrigger disabled={checkActionButtonDisabled()}>
                 <Button
                   className=" mb-1 h-16 w-40 font-bold text-xl !text-white !bg-pink-600"
                   disabled={checkActionButtonDisabled()}
+=======
+              <PopoverTrigger disabled={hangPositionSelected === "" || screenDisabled || climbStarted === false}>
+                <Button
+                  className="mb-1 h-16 w-40 font-bold text-xl !text-white !bg-pink-600 hover:dark:bg-white"
+                  disabled={hangPositionSelected === "" || screenDisabled || climbStarted === false}
+>>>>>>> 59282ce (final commit before rebase hopefully - added brownout buttons, better button feedback for endgame screen, as well as reworking how recording climbs work w the start climb button)
                 >
                   {" "}
                   Failed Attempt
                 </Button>
               </PopoverTrigger>
-
               <PopoverContent className="w-[12rem]" side="right">
                 <ScoutActionButton
                   actionName={ACTION_NAMES.CLIMB.FAIL}
                   gamePiece={GAME_PIECES.CAGE.SHALLOW}
                   location={hangPositionSelected}
-                  className="mb-1 h-16 w-40 font-bold text-xl !bg-pink-600"
+                  className={popoverButton1Style}
                   onClick={() => {
+<<<<<<< HEAD
                     setActionDone(true);
                     setCurrentAction("Shallow Climb Failed ");
                     setIsMatchSelectionOpen(false);
@@ -156,6 +209,16 @@ export default function EndgameScreen() {
                       positionSelected: hangPositionSelected,
                       actionMessage: "Shallow Climb Failed ",
                     });
+=======
+                    toast.error("Robot failed shallow climb!");
+                    setCurrentAction("Shallow Climb Failed ");
+                    setTimeout(() => setIsMatchSelectionOpen(false),500)
+                    setPopoverButton1Style("mb-1 h-16 w-40 font-bold text-xl !bg-white !text-black");
+                    setTimeout(() => setPopoverButton1Style("mb-1 h-16 w-40 font-bold text-xl !bg-pink-600 !text-white"),1000);
+                    setClimbStarted(false)
+                    
+                    
+>>>>>>> 59282ce (final commit before rebase hopefully - added brownout buttons, better button feedback for endgame screen, as well as reworking how recording climbs work w the start climb button)
                   }}
                   disabled={checkActionButtonDisabled()}
                   label="Shallow Hang"
@@ -165,8 +228,9 @@ export default function EndgameScreen() {
                   actionName={ACTION_NAMES.CLIMB.FAIL}
                   gamePiece={GAME_PIECES.CAGE.DEEP}
                   location={hangPositionSelected}
-                  className=" mb-1 h-16 w-40 font-bold text-xl !bg-pink-600"
+                  className={popoverButton2Style}
                   onClick={() => {
+<<<<<<< HEAD
                     setActionDone(true);
                     setCurrentAction("Deep Climb Failed");
                     setIsMatchSelectionOpen(false);
@@ -175,6 +239,14 @@ export default function EndgameScreen() {
                       positionSelected: hangPositionSelected,
                       actionMessage: "Deep Climb Failed",
                     });
+=======
+                    toast.error("Robot failed deep climb!");
+                    setCurrentAction("Deep Climb Failed");
+                    setTimeout(() => setIsMatchSelectionOpen(false),500)
+                    setPopoverButton2Style("mb-1 h-16 w-40 font-bold text-xl !bg-white !text-black");
+                    setTimeout(() => setPopoverButton2Style("mb-1 h-16 w-40 font-bold text-xl !bg-pink-600 !text-white"),1000);
+                    setClimbStarted(false)
+>>>>>>> 59282ce (final commit before rebase hopefully - added brownout buttons, better button feedback for endgame screen, as well as reworking how recording climbs work w the start climb button)
                   }}
                   disabled={checkActionButtonDisabled()}
                   label="Deep Hang"
@@ -185,6 +257,7 @@ export default function EndgameScreen() {
               actionName={ACTION_NAMES.CLIMB.NOTHING}
               gamePiece={GAME_PIECES.NOGAMEPIECE}
               location={hangPositionSelected}
+<<<<<<< HEAD
               className=" mb-1 h-16 w-40 font-bold text-xl bg-pink-600"
               disabled={checkActionButtonDisabled()}
               onClick={() => {
@@ -195,10 +268,41 @@ export default function EndgameScreen() {
                   positionSelected: hangPositionSelected,
                   actionMessage: "Endgame action skipped",
                 });
+=======
+              className={button4Style}
+              disabled={hangPositionSelected === "" || screenDisabled || climbStarted}
+              onClick={() => {
+                toast.error("Robot did not attempt endgame action!");
+                setCurrentAction("Endgame action skipped");
+                setButton4Style("mb-1 h-16 w-40 font-bold text-xl bg-white text-black")
+                setTimeout(() => setButton4Style("mb-1 h-16 w-40 font-bold text-xl bg-blue-600"),500)
+>>>>>>> 59282ce (final commit before rebase hopefully - added brownout buttons, better button feedback for endgame screen, as well as reworking how recording climbs work w the start climb button)
               }}
               label="Not Attempted"
             />
           </div>
+
+          <div className="flex flex-col justify-center h-full">
+            <ScoutActionButton
+              actionName={ACTION_NAMES.CLIMB.START}
+              gamePiece={GAME_PIECES.NOGAMEPIECE}
+              location={hangPositionSelected}
+              className={startClimbButtonStyle}
+              disabled={hangPositionSelected == "" || climbStarted === true || screenDisabled}
+              onClick={() => {
+                toast.error("Climb started!");
+                setCurrentAction("Started Climb Attempt");
+                setStartClimbButtonStyle("mb-1 h-16 w-40 font-bold text-xl bg-white text-black")
+                setTimeout(() => setStartClimbButtonStyle("mb-1 h-16 w-40 font-bold text-xl bg-green-700"),500)
+                setClimbStarted(true)
+              }}
+              label="Start Climb"
+            />
+          </div>
+
+
+
+
           <div
             className={cn(
               "flex flex-col my-[3rem] gap-2 mx-[5rem]",
@@ -210,13 +314,18 @@ export default function EndgameScreen() {
               className={cn(
                 "h-12 w-40 font-bold text-xl opacity-90 !bg-cyan-100",
                 hangPositionSelected === LOCATIONS.BARGE.OUTER &&
-                  "dark:ring-2 ring-yellow-400  ring-offset-4"
+                "dark:ring-2 ring-yellow-400  ring-offset-4"
               )}
               onClick={() => {
                 setPositionSelected(true);
                 setHangPositionSelected(LOCATIONS.BARGE.OUTER);
               }}
+<<<<<<< HEAD
               disabled={hangPositionSelected !== ""}
+=======
+
+              disabled={screenDisabled}
+>>>>>>> 59282ce (final commit before rebase hopefully - added brownout buttons, better button feedback for endgame screen, as well as reworking how recording climbs work w the start climb button)
             >
               Far Cage
             </Button>
@@ -224,13 +333,17 @@ export default function EndgameScreen() {
               className={cn(
                 " h-12 w-40  font-bold text-xl opacity-90 !bg-cyan-100",
                 hangPositionSelected === LOCATIONS.BARGE.MIDDLE &&
-                  "dark:ring-2 ring-yellow-400  ring-offset-4"
+                "dark:ring-2 ring-yellow-400  ring-offset-4"
               )}
               onClick={() => {
                 setHangPositionSelected(LOCATIONS.BARGE.MIDDLE);
                 setPositionSelected(true);
               }}
+<<<<<<< HEAD
               disabled={hangPositionSelected !== ""}
+=======
+              disabled={screenDisabled}
+>>>>>>> 59282ce (final commit before rebase hopefully - added brownout buttons, better button feedback for endgame screen, as well as reworking how recording climbs work w the start climb button)
             >
               Middle Cage
             </Button>
@@ -238,13 +351,17 @@ export default function EndgameScreen() {
               className={cn(
                 " mb-1 h-12 w-40  font-bold text-xl opacity-90 !bg-cyan-100",
                 hangPositionSelected === LOCATIONS.BARGE.INNER &&
-                  "dark:ring-2 ring-yellow-400  ring-offset-4"
+                "dark:ring-2 ring-yellow-400  ring-offset-4"
               )}
               onClick={() => {
                 setPositionSelected(true);
                 setHangPositionSelected(LOCATIONS.BARGE.INNER);
               }}
+<<<<<<< HEAD
               disabled={hangPositionSelected !== ""}
+=======
+              disabled={screenDisabled}
+>>>>>>> 59282ce (final commit before rebase hopefully - added brownout buttons, better button feedback for endgame screen, as well as reworking how recording climbs work w the start climb button)
             >
               Near Cage
             </Button>
@@ -256,6 +373,30 @@ export default function EndgameScreen() {
           onClick={() => {
             screenContext.prevScreen();
           }}
+        />
+
+        <ScoutActionButton
+          className="bg-red-500 flex items-center justify-center text-black font-bold text-xl h-20 w-64 px-4 py-2"
+          actionName={ACTION_NAMES.BROWN_OUT}
+          gamePiece="null"
+          location="null"
+          label={brownOutLabel}
+          onClick={() => {
+            if (screenDisabled == false){
+              setScreenDisabled(true);
+              toast.error("Robot has stopped. Screen disabled!");
+              setBrownOutLabel("ROBOT RESTARTED")
+
+            }
+            else{
+              setScreenDisabled(false)
+              toast.error("Robot has restarted. Screen enabled!");
+              setBrownOutLabel("BROWNOUT")
+            } 
+    
+          }}
+
+
         />
 
         <ContinueButton

--- a/src/app/scout/[eventCode]/components/endgame-screen.tsx
+++ b/src/app/scout/[eventCode]/components/endgame-screen.tsx
@@ -12,11 +12,6 @@ import {
   LOCATIONS,
   ACTION_NAMES,
 } from "~/app/scout/[eventCode]/constants";
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from "~/components/ui/popover";
 import ContinueButton from "./common/continue-button";
 import BackButton from "./common/back-button";
 import UndoActionButton from "./common/undo-action-button";
@@ -28,48 +23,21 @@ export default function EndgameScreen() {
   const screenContext = useContext(ScoutScreenContext);
   const [hangPositionSelected, setHangPositionSelected] = useState<string>("");
   const [currentAction, setCurrentAction] = useState<string>("");
-  const [isMatchSelectionOpen, setIsMatchSelectionOpen] = useState(false);
   const [actionDone, setActionDone] = useState(false);
   const [positionSelected, setPositionSelected] = useState(false);
-  useEffect(() => {
-    setCurrentAction(context.previousEndgameAction.actionMessage);
-    setHangPositionSelected(context.previousEndgameAction.positionSelected);
-    setActionDone(context.previousEndgameAction.actionDone);
-  }, [context.previousEndgameAction]);
+  const [climbStarted, setClimbStarted] = useState(false);
 
   function checkActionButtonDisabled() {
-    let disability = false;
-    if (!positionSelected || actionDone) {
-      disability = true;
-    }
-
-    return disability;
+    return !positionSelected || actionDone;
   }
 
-  const [screenDisabled, setScreenDisabled] = useState(false);
-  const [climbStarted, setClimbStarted] = useState(false);
-  const [brownOutLabel, setBrownOutLabel] = useState("BROWNOUT");
-  const [button1Style, setButton1Style] = useState(
-    "mb-1 h-16 w-40 font-bold text-xl bg-pink-600"
-  );
-  const [button2Style, setButton2Style] = useState(
-    "mb-1 h-16 w-40 font-bold text-xl bg-pink-600"
-  );
-  const [button3Style, setButton3Style] = useState(
-    "mb-1 h-16 w-40 font-bold text-xl bg-blue-500"
-  );
-  const [button4Style, setButton4Style] = useState(
-    "mb-1 h-16 w-40 font-bold text-xl bg-blue-500"
-  );
-  const [popoverButton1Style, setPopoverButton1Style] = useState(
-    "mb-1 h-16 w-40 font-bold text-xl !bg-pink-600 !text-white"
-  );
-  const [popoverButton2Style, setPopoverButton2Style] = useState(
-    "mb-1 h-16 w-40 font-bold text-xl !bg-pink-600 !text-white"
-  );
-  const [startClimbButtonStyle, setStartClimbButtonStyle] = useState(
-    "mb-1 h-16 w-40 font-bold text-xl !bg-green-700 !text-white"
-  );
+  useEffect(() => {
+    setCurrentAction(context.previousEndgameAction.actionMessage);
+    setActionDone(context.previousEndgameAction.actionDone);
+  }, []);
+
+  console.log(context.actions);
+
   return (
     <>
       <div className="flex flex-row">
@@ -79,13 +47,16 @@ export default function EndgameScreen() {
           </div>
           <UndoActionButton
             onClick={() => {
-              if (hangPositionSelected !== "") {
-                setHangPositionSelected("");
-                setActionDone(false);
-                setCurrentAction("");
-                setPositionSelected(false);
-                setClimbStarted(false);
-              }
+              setHangPositionSelected("");
+              setActionDone(false);
+              setPositionSelected(false);
+              setClimbStarted(false);
+              setCurrentAction("");
+              context.setPreviousEndgameAction({
+                actionDone: false,
+                positionSelected: "",
+                actionMessage: "",
+              });
             }}
             className="text-xl bg-red-600 h-16 w-40"
           />
@@ -96,53 +67,18 @@ export default function EndgameScreen() {
       <FieldImage imageSize="100%" fieldSize="half">
         <div
           className={cn(
-            "flex justify-between gap-20 h-full",
+            "flex justify-evenly gap-20 h-full",
             getFlexDirection(context.uiOrientation, context.allianceColour).row
           )}
         >
-          <div className="flex flex-col justify-evenly h-full mx-28">
-            <ScoutActionButton
-              actionName={ACTION_NAMES.CLIMB.SUCCESS}
-              gamePiece={GAME_PIECES.CAGE.SHALLOW}
-              location={hangPositionSelected}
-              className={button1Style}
-              onClick={() => {
-                setActionDone(true);
-                setCurrentAction("Successfully Climbed Shallow");
-                context.setPreviousEndgameAction({
-                  actionDone: true,
-                  positionSelected: hangPositionSelected,
-                  actionMessage: "Successfully Climbed Shallow",
-                });
-                toast.error("Robot climbed shallow cage!");
-                setCurrentAction("Successfully Climbed Shallow Cage");
-                setClimbStarted(false);
-                setButton1Style(
-                  "mb-1 h-16 w-40 font-bold text-xl bg-white text-black"
-                );
-                setTimeout(
-                  () =>
-                    setButton1Style(
-                      "mb-1 h-16 w-40 font-bold text-xl bg-pink-600"
-                    ),
-                  500
-                );
-              }}
-              disabled={
-                checkActionButtonDisabled() ||
-                screenDisabled ||
-                climbStarted === false
-              }
-              label="Shallow Hang"
-            />
+          <div className="flex flex-col justify-evenly h-full">
             <ScoutActionButton
               actionName={ACTION_NAMES.CLIMB.SUCCESS}
               gamePiece={GAME_PIECES.CAGE.DEEP}
               location={hangPositionSelected}
-              className={button2Style}
+              className={"mb-1 h-16 w-40 font-bold text-xl bg-blue-500"}
               onClick={() => {
                 setActionDone(true);
-                setCurrentAction("Successfully Climbed Deep");
                 context.setPreviousEndgameAction({
                   actionDone: true,
                   positionSelected: hangPositionSelected,
@@ -152,33 +88,51 @@ export default function EndgameScreen() {
                 toast.error("Robot climbed deep cage!");
                 setCurrentAction("Successfully Climbed Deep Cage");
                 setClimbStarted(false);
-                setButton2Style(
-                  "mb-1 h-16 w-40 font-bold text-xl bg-white text-black"
-                );
-                setTimeout(
-                  () =>
-                    setButton2Style(
-                      "mb-1 h-16 w-40 font-bold text-xl bg-pink-600"
-                    ),
-                  500
-                );
+                setHangPositionSelected("");
+                setPositionSelected(false);
               }}
               disabled={
                 checkActionButtonDisabled() ||
-                screenDisabled ||
-                climbStarted === false
+                !climbStarted ||
+                context.isBrownedOut
               }
               label="Deep Hang"
+              shouldBeHidden={false}
+            />
+            <ScoutActionButton
+              actionName={ACTION_NAMES.CLIMB.SUCCESS}
+              gamePiece={GAME_PIECES.CAGE.SHALLOW}
+              location={hangPositionSelected}
+              className={"mb-1 h-16 w-40 font-bold text-xl bg-blue-500"}
+              onClick={() => {
+                setActionDone(true);
+                context.setPreviousEndgameAction({
+                  actionDone: true,
+                  positionSelected: hangPositionSelected,
+                  actionMessage: "Successfully Climbed Shallow",
+                });
+                toast.error("Robot climbed shallow cage!");
+                setCurrentAction("Successfully Climbed Shallow Cage");
+                setClimbStarted(false);
+                setHangPositionSelected("");
+                setPositionSelected(false);
+              }}
+              disabled={
+                checkActionButtonDisabled() ||
+                !climbStarted ||
+                context.isBrownedOut
+              }
+              label="Shallow Hang"
+              shouldBeHidden={false}
             />
 
             <ScoutActionButton
               actionName={ACTION_NAMES.PARK}
               gamePiece={GAME_PIECES.NOGAMEPIECE}
               location={hangPositionSelected}
-              className={button3Style}
+              className={"mb-1 h-16 w-40 font-bold text-xl bg-blue-500"}
               onClick={() => {
                 setActionDone(true);
-                setCurrentAction("Successfully Parked");
                 context.setPreviousEndgameAction({
                   actionDone: true,
                   positionSelected: hangPositionSelected,
@@ -187,129 +141,106 @@ export default function EndgameScreen() {
 
                 toast.error("Robot parked!");
                 setCurrentAction("Successfully Parked");
-                setButton3Style(
-                  "mb-1 h-16 w-40 font-bold text-xl bg-white text-black"
-                );
-                setTimeout(
-                  () =>
-                    setButton3Style(
-                      "mb-1 h-16 w-40 font-bold text-xl bg-blue-500"
-                    ),
-                  500
-                );
+                setHangPositionSelected("");
+                setPositionSelected(false);
               }}
               disabled={
-                checkActionButtonDisabled() || screenDisabled || climbStarted
+                checkActionButtonDisabled() ||
+                climbStarted ||
+                context.isBrownedOut
               }
               label="Park"
+              shouldBeHidden={false}
             />
 
-            <Popover
-              open={isMatchSelectionOpen}
-              onOpenChange={setIsMatchSelectionOpen}
-            >
-              <PopoverTrigger
-                disabled={
-                  checkActionButtonDisabled() ||
-                  screenDisabled ||
-                  climbStarted === false
-                }
-              >
-                <Button
-                  className="mb-1 h-16 w-40 font-bold text-xl !text-white !bg-pink-600 hover:dark:bg-white"
-                  disabled={
-                    checkActionButtonDisabled() ||
-                    screenDisabled ||
-                    climbStarted === false
-                  }
-                >
-                  {" "}
-                  Failed Attempt
-                </Button>
-              </PopoverTrigger>
-              <PopoverContent className="w-[12rem]" side="right">
-                <ScoutActionButton
-                  actionName={ACTION_NAMES.CLIMB.FAIL}
-                  gamePiece={GAME_PIECES.CAGE.SHALLOW}
-                  location={hangPositionSelected}
-                  className={popoverButton1Style}
-                  onClick={() => {
-                    setActionDone(true);
-                    setCurrentAction("Shallow Climb Failed ");
-                    setIsMatchSelectionOpen(false);
-                    context.setPreviousEndgameAction({
-                      actionDone: true,
-                      positionSelected: hangPositionSelected,
-                      actionMessage: "Shallow Climb Failed ",
-                    });
-                    toast.error("Robot failed shallow climb!");
-                    setCurrentAction("Shallow Climb Failed ");
-                    setTimeout(() => setIsMatchSelectionOpen(false), 500);
-                    setPopoverButton1Style(
-                      "mb-1 h-16 w-40 font-bold text-xl !bg-white !text-black"
-                    );
-                    setTimeout(
-                      () =>
-                        setPopoverButton1Style(
-                          "mb-1 h-16 w-40 font-bold text-xl !bg-pink-600 !text-white"
-                        ),
-                      1000
-                    );
-                    setClimbStarted(false);
-                  }}
-                  disabled={
-                    checkActionButtonDisabled() ||
-                    screenDisabled ||
-                    climbStarted === false
-                  }
-                  label="Shallow Hang"
-                />
+            <ScoutActionButton
+              actionName={ACTION_NAMES.CLIMB.FAIL}
+              gamePiece={GAME_PIECES.CAGE.DEEP}
+              location={hangPositionSelected}
+              className={
+                "mb-1 h-16 w-40 font-bold text-xl !bg-red-500 text-black"
+              }
+              onClick={() => {
+                setActionDone(true);
+                context.setPreviousEndgameAction({
+                  actionDone: true,
+                  positionSelected: hangPositionSelected,
+                  actionMessage: "Deep Climb Failed",
+                });
+                toast.error("Robot failed deep climb!");
+                setCurrentAction("Deep Climb Failed");
+                setClimbStarted(false);
+                setHangPositionSelected("");
+                setPositionSelected(false);
+              }}
+              disabled={
+                checkActionButtonDisabled() ||
+                climbStarted === false ||
+                context.isBrownedOut
+              }
+              label="Failed Deep"
+              shouldBeHidden={false}
+            />
 
-                <ScoutActionButton
-                  actionName={ACTION_NAMES.CLIMB.FAIL}
-                  gamePiece={GAME_PIECES.CAGE.DEEP}
-                  location={hangPositionSelected}
-                  className={popoverButton2Style}
-                  onClick={() => {
-                    setActionDone(true);
-                    setCurrentAction("Deep Climb Failed");
-                    setIsMatchSelectionOpen(false);
-                    context.setPreviousEndgameAction({
-                      actionDone: true,
-                      positionSelected: hangPositionSelected,
-                      actionMessage: "Deep Climb Failed",
-                    });
-                    toast.error("Robot failed deep climb!");
-                    setCurrentAction("Deep Climb Failed");
-                    setTimeout(() => setIsMatchSelectionOpen(false), 500);
-                    setPopoverButton2Style(
-                      "mb-1 h-16 w-40 font-bold text-xl !bg-white !text-black"
-                    );
-                    setTimeout(
-                      () =>
-                        setPopoverButton2Style(
-                          "mb-1 h-16 w-40 font-bold text-xl !bg-pink-600 !text-white"
-                        ),
-                      1000
-                    );
-                    setClimbStarted(false);
-                  }}
-                  disabled={
-                    checkActionButtonDisabled() ||
-                    screenDisabled ||
-                    climbStarted === false
-                  }
-                  label="Deep Hang"
-                />
-              </PopoverContent>
-            </Popover>
+            <ScoutActionButton
+              actionName={ACTION_NAMES.CLIMB.FAIL}
+              gamePiece={GAME_PIECES.CAGE.SHALLOW}
+              location={hangPositionSelected}
+              className={
+                "mb-1 h-16 w-40 font-bold text-xl !bg-red-500 text-black"
+              }
+              onClick={() => {
+                setActionDone(true);
+                context.setPreviousEndgameAction({
+                  actionDone: true,
+                  positionSelected: hangPositionSelected,
+                  actionMessage: "Shallow Climb Failed ",
+                });
+                toast.error("Robot failed shallow climb!");
+                setCurrentAction("Shallow Climb Failed ");
+                setClimbStarted(false);
+                setHangPositionSelected("");
+                setPositionSelected(false);
+              }}
+              disabled={
+                checkActionButtonDisabled() ||
+                climbStarted === false ||
+                context.isBrownedOut
+              }
+              label="Failed Shallow"
+              shouldBeHidden={false}
+            />
+          </div>
+
+          <div className="flex flex-col justify-center h-full gap-4">
+            <ScoutActionButton
+              actionName={ACTION_NAMES.CLIMB.START}
+              gamePiece={GAME_PIECES.NOGAMEPIECE}
+              location={hangPositionSelected}
+              className={
+                "mb-1 h-16 w-40 font-bold text-xl !bg-green-700 !text-white"
+              }
+              onClick={() => {
+                toast.error("Climb started!");
+                setCurrentAction("Started Climb Attempt");
+                setClimbStarted(true);
+              }}
+              label="Start Climb"
+              shouldBeHidden={false}
+              disabled={
+                !positionSelected || !!currentAction || context.isBrownedOut
+              }
+            />
             <ScoutActionButton
               actionName={ACTION_NAMES.CLIMB.NOTHING}
               gamePiece={GAME_PIECES.NOGAMEPIECE}
-              location={hangPositionSelected}
-              className={button4Style}
+              location={LOCATIONS.BARGE.BASE}
+              className={"mb-1 h-16 w-40 font-bold text-xl bg-red-500"}
               disabled={
-                checkActionButtonDisabled() || screenDisabled || climbStarted
+                climbStarted ||
+                positionSelected ||
+                actionDone ||
+                context.isBrownedOut
               }
               onClick={() => {
                 setActionDone(true);
@@ -320,97 +251,58 @@ export default function EndgameScreen() {
                   positionSelected: hangPositionSelected,
                   actionMessage: "Endgame action skipped",
                 });
-                setButton4Style(
-                  "mb-1 h-16 w-40 font-bold text-xl bg-white text-black"
-                );
-                setTimeout(
-                  () =>
-                    setButton4Style(
-                      "mb-1 h-16 w-40 font-bold text-xl bg-blue-600"
-                    ),
-                  500
-                );
               }}
               label="Not Attempted"
-            />
-          </div>
-
-          <div className="flex flex-col justify-center h-full">
-            <ScoutActionButton
-              actionName={ACTION_NAMES.CLIMB.START}
-              gamePiece={GAME_PIECES.NOGAMEPIECE}
-              location={hangPositionSelected}
-              className={startClimbButtonStyle}
-              disabled={
-                checkActionButtonDisabled() ||
-                climbStarted === true ||
-                screenDisabled
-              }
-              onClick={() => {
-                toast.error("Climb started!");
-                setCurrentAction("Started Climb Attempt");
-                setStartClimbButtonStyle(
-                  "mb-1 h-16 w-40 font-bold text-xl bg-white text-black"
-                );
-                setTimeout(
-                  () =>
-                    setStartClimbButtonStyle(
-                      "mb-1 h-16 w-40 font-bold text-xl bg-green-700"
-                    ),
-                  500
-                );
-                setClimbStarted(true);
-              }}
-              label="Start Climb"
+              shouldBeHidden={false}
             />
           </div>
 
           <div
             className={cn(
-              "flex flex-col my-[3rem] gap-2 mx-[5rem]",
+              "flex flex-col my-[3rem] gap-2",
               getFlexDirection(context.uiOrientation, context.allianceColour)
                 .col
             )}
           >
             <Button
               className={cn(
-                "h-12 w-40 font-bold text-xl opacity-90 !bg-cyan-100",
+                "h-12 w-40 font-bold text-xl !bg-white opacity-80",
                 hangPositionSelected === LOCATIONS.BARGE.OUTER &&
-                  "dark:ring-2 ring-yellow-400  ring-offset-4"
+                  "dark:ring-4 ring-red-500"
               )}
               onClick={() => {
                 setPositionSelected(true);
                 setHangPositionSelected(LOCATIONS.BARGE.OUTER);
               }}
-              disabled={screenDisabled}
+              disabled={actionDone || context.isBrownedOut}
             >
               Far Cage
             </Button>
             <Button
               className={cn(
-                " h-12 w-40  font-bold text-xl opacity-90 !bg-cyan-100",
+                " h-12 w-40  font-bold text-xl !bg-white opacity-80",
                 hangPositionSelected === LOCATIONS.BARGE.MIDDLE &&
-                  "dark:ring-2 ring-yellow-400  ring-offset-4"
+                  "dark:ring-4 ring-red-500"
               )}
               onClick={() => {
                 setHangPositionSelected(LOCATIONS.BARGE.MIDDLE);
                 setPositionSelected(true);
               }}
-              disabled={screenDisabled}
+              disabled={actionDone || context.isBrownedOut}
             >
               Middle Cage
             </Button>
             <Button
               className={cn(
-                " mb-1 h-12 w-40  font-bold text-xl opacity-90 !bg-cyan-100",
+                " mb-1 h-12 w-40  font-bold text-xl !bg-white opacity-80",
                 hangPositionSelected === LOCATIONS.BARGE.INNER &&
-                  "dark:ring-2 ring-yellow-400  ring-offset-4"
+                  "dark:ring-4 ring-red-500"
               )}
               onClick={() => {
                 setPositionSelected(true);
                 setHangPositionSelected(LOCATIONS.BARGE.INNER);
               }}
-              disabled={screenDisabled}
+              disabled={actionDone || context.isBrownedOut}
             >
               Near Cage
             </Button>
@@ -426,20 +318,21 @@ export default function EndgameScreen() {
 
         <ScoutActionButton
           className="bg-red-500 flex items-center justify-center text-black font-bold text-xl h-20 w-64 px-4 py-2"
-          actionName={ACTION_NAMES.BROWN_OUT}
-          gamePiece="None"
-          location="None"
-          label={brownOutLabel}
+          actionName={
+            context.isBrownedOut
+              ? ACTION_NAMES.BROWN_OUT_END
+              : ACTION_NAMES.BROWN_OUT
+          }
+          gamePiece="null"
+          location="null"
+          label={context.isBrownedOut ? "ROBOT RESTARTED" : "BROWNOUT"}
           onClick={() => {
-            if (screenDisabled == false) {
-              setScreenDisabled(true);
-              toast.error("Robot has stopped. Screen disabled!");
-              setBrownOutLabel("ROBOT RESTARTED");
-            } else {
-              setScreenDisabled(false);
-              toast.error("Robot has restarted. Screen enabled!");
-              setBrownOutLabel("BROWNOUT");
-            }
+            toast.error(
+              context.isBrownedOut
+                ? "Robot has restarted. Screen enabled!"
+                : "Robot has stopped. Screen disabled!"
+            );
+            context.setIsBrownedOut(!context.isBrownedOut);
           }}
         />
 

--- a/src/app/scout/[eventCode]/components/endgame-screen.tsx
+++ b/src/app/scout/[eventCode]/components/endgame-screen.tsx
@@ -22,6 +22,7 @@ import BackButton from "./common/back-button";
 import UndoActionButton from "./common/undo-action-button";
 import { getFlexDirection } from "../utils";
 import { toast } from "sonner";
+
 export default function EndgameScreen() {
   const context = useContext(ScoutDataContext);
   const screenContext = useContext(ScoutScreenContext);
@@ -83,6 +84,7 @@ export default function EndgameScreen() {
                 setActionDone(false);
                 setCurrentAction("");
                 setPositionSelected(false);
+                setClimbStarted(false);
               }
             }}
             className="text-xl bg-red-600 h-16 w-40"
@@ -425,8 +427,8 @@ export default function EndgameScreen() {
         <ScoutActionButton
           className="bg-red-500 flex items-center justify-center text-black font-bold text-xl h-20 w-64 px-4 py-2"
           actionName={ACTION_NAMES.BROWN_OUT}
-          gamePiece="null"
-          location="null"
+          gamePiece="None"
+          location="None"
           label={brownOutLabel}
           onClick={() => {
             if (screenDisabled == false) {

--- a/src/app/scout/[eventCode]/components/endgame-screen.tsx
+++ b/src/app/scout/[eventCode]/components/endgame-screen.tsx
@@ -28,7 +28,6 @@ export default function EndgameScreen() {
   const [hangPositionSelected, setHangPositionSelected] = useState<string>("");
   const [currentAction, setCurrentAction] = useState<string>("");
   const [isMatchSelectionOpen, setIsMatchSelectionOpen] = useState(false);
-<<<<<<< HEAD
   const [actionDone, setActionDone] = useState(false);
   const [positionSelected, setPositionSelected] = useState(false);
   useEffect(() => {
@@ -36,6 +35,8 @@ export default function EndgameScreen() {
     setHangPositionSelected(context.previousEndgameAction.positionSelected);
     setActionDone(context.previousEndgameAction.actionDone);
   }, [context.previousEndgameAction]);
+
+
   function checkActionButtonDisabled() {
     let disability = false;
     if (!positionSelected || actionDone) {
@@ -45,7 +46,6 @@ export default function EndgameScreen() {
     return disability;
   }
 
-=======
   const [screenDisabled, setScreenDisabled] = useState(false);
   const [climbStarted, setClimbStarted] = useState(false);
   const [brownOutLabel, setBrownOutLabel] = useState("BROWNOUT")
@@ -56,7 +56,6 @@ export default function EndgameScreen() {
   const [popoverButton1Style, setPopoverButton1Style] = useState("mb-1 h-16 w-40 font-bold text-xl !bg-pink-600 !text-white")
   const [popoverButton2Style, setPopoverButton2Style] = useState("mb-1 h-16 w-40 font-bold text-xl !bg-pink-600 !text-white")
   const [startClimbButtonStyle, setStartClimbButtonStyle] = useState("mb-1 h-16 w-40 font-bold text-xl !bg-green-700 !text-white")
->>>>>>> 59282ce (final commit before rebase hopefully - added brownout buttons, better button feedback for endgame screen, as well as reworking how recording climbs work w the start climb button)
   return (
     <>
       <div className="flex flex-row">
@@ -88,7 +87,10 @@ export default function EndgameScreen() {
         >
           <div className="flex flex-col justify-evenly h-full mx-28">
             <ScoutActionButton
-              className=" mb-1 h-16 w-40 font-bold text-xl bg-pink-600"
+              actionName={ACTION_NAMES.CLIMB.SUCCESS}
+              gamePiece={GAME_PIECES.CAGE.SHALLOW}
+              location={hangPositionSelected}
+              className={button1Style}
               onClick={() => {
                 setActionDone(true);
                 setCurrentAction("Successfully Climbed Shallow");
@@ -97,15 +99,6 @@ export default function EndgameScreen() {
                   positionSelected: hangPositionSelected,
                   actionMessage: "Successfully Climbed Shallow",
                 });
-              }}
-              actionName={ACTION_NAMES.CLIMB.SUCCESS}
-              gamePiece={GAME_PIECES.CAGE.SHALLOW}
-              location={hangPositionSelected}
-<<<<<<< HEAD
-              disabled={checkActionButtonDisabled()}
-=======
-              className={button1Style}
-              onClick={() => {
                 toast.error("Robot climbed shallow cage!");
                 setCurrentAction("Successfully Climbed Shallow Cage");
                 setClimbStarted(false)
@@ -113,8 +106,7 @@ export default function EndgameScreen() {
                 setTimeout(() => setButton1Style("mb-1 h-16 w-40 font-bold text-xl bg-pink-600"),500)
               }}
 
-              disabled={hangPositionSelected === "" || screenDisabled || climbStarted === false}
->>>>>>> 59282ce (final commit before rebase hopefully - added brownout buttons, better button feedback for endgame screen, as well as reworking how recording climbs work w the start climb button)
+              disabled={checkActionButtonDisabled() || screenDisabled || climbStarted === false}
               label="Shallow Hang"
             />
             <ScoutActionButton
@@ -123,7 +115,6 @@ export default function EndgameScreen() {
               location={hangPositionSelected}
               className={button2Style}
               onClick={() => {
-<<<<<<< HEAD
                 setActionDone(true);
                 setCurrentAction("Successfully Climbed Deep");
                 context.setPreviousEndgameAction({
@@ -131,17 +122,14 @@ export default function EndgameScreen() {
                   positionSelected: hangPositionSelected,
                   actionMessage: "Successfully Climbed Deep",
                 });
-              }}
-              disabled={checkActionButtonDisabled()}
-=======
+           
                 toast.error("Robot climbed deep cage!");
                 setCurrentAction("Successfully Climbed Deep Cage");
                 setClimbStarted(false)
                 setButton2Style("mb-1 h-16 w-40 font-bold text-xl bg-white text-black")
                 setTimeout(() => setButton2Style("mb-1 h-16 w-40 font-bold text-xl bg-pink-600"),500)
               }}
-              disabled={hangPositionSelected === "" || screenDisabled || climbStarted === false}
->>>>>>> 59282ce (final commit before rebase hopefully - added brownout buttons, better button feedback for endgame screen, as well as reworking how recording climbs work w the start climb button)
+              disabled={checkActionButtonDisabled() || screenDisabled || climbStarted === false}
               label="Deep Hang"
             />
 
@@ -151,7 +139,6 @@ export default function EndgameScreen() {
               location={hangPositionSelected}
               className={button3Style}
               onClick={() => {
-<<<<<<< HEAD
                 setActionDone(true);
                 setCurrentAction("Successfully Parked");
                 context.setPreviousEndgameAction({
@@ -159,16 +146,13 @@ export default function EndgameScreen() {
                   positionSelected: hangPositionSelected,
                   actionMessage: "Successfully Parked",
                 });
-              }}
-              disabled={checkActionButtonDisabled()}
-=======
+              
                 toast.error("Robot parked!");
                 setCurrentAction("Successfully Parked");
                 setButton3Style("mb-1 h-16 w-40 font-bold text-xl bg-white text-black")
                 setTimeout(() => setButton3Style("mb-1 h-16 w-40 font-bold text-xl bg-blue-500"),500)
               }}
-              disabled={hangPositionSelected === "" || screenDisabled || climbStarted}
->>>>>>> 59282ce (final commit before rebase hopefully - added brownout buttons, better button feedback for endgame screen, as well as reworking how recording climbs work w the start climb button)
+              disabled={checkActionButtonDisabled() || screenDisabled || climbStarted}
               label="Park"
             />
 
@@ -177,17 +161,10 @@ export default function EndgameScreen() {
               onOpenChange={setIsMatchSelectionOpen}
               
             >
-<<<<<<< HEAD
-              <PopoverTrigger disabled={checkActionButtonDisabled()}>
-                <Button
-                  className=" mb-1 h-16 w-40 font-bold text-xl !text-white !bg-pink-600"
-                  disabled={checkActionButtonDisabled()}
-=======
-              <PopoverTrigger disabled={hangPositionSelected === "" || screenDisabled || climbStarted === false}>
+              <PopoverTrigger disabled={checkActionButtonDisabled() || screenDisabled || climbStarted === false}>
                 <Button
                   className="mb-1 h-16 w-40 font-bold text-xl !text-white !bg-pink-600 hover:dark:bg-white"
-                  disabled={hangPositionSelected === "" || screenDisabled || climbStarted === false}
->>>>>>> 59282ce (final commit before rebase hopefully - added brownout buttons, better button feedback for endgame screen, as well as reworking how recording climbs work w the start climb button)
+                  disabled={checkActionButtonDisabled() || screenDisabled || climbStarted === false}
                 >
                   {" "}
                   Failed Attempt
@@ -200,7 +177,6 @@ export default function EndgameScreen() {
                   location={hangPositionSelected}
                   className={popoverButton1Style}
                   onClick={() => {
-<<<<<<< HEAD
                     setActionDone(true);
                     setCurrentAction("Shallow Climb Failed ");
                     setIsMatchSelectionOpen(false);
@@ -209,18 +185,14 @@ export default function EndgameScreen() {
                       positionSelected: hangPositionSelected,
                       actionMessage: "Shallow Climb Failed ",
                     });
-=======
                     toast.error("Robot failed shallow climb!");
                     setCurrentAction("Shallow Climb Failed ");
                     setTimeout(() => setIsMatchSelectionOpen(false),500)
                     setPopoverButton1Style("mb-1 h-16 w-40 font-bold text-xl !bg-white !text-black");
                     setTimeout(() => setPopoverButton1Style("mb-1 h-16 w-40 font-bold text-xl !bg-pink-600 !text-white"),1000);
-                    setClimbStarted(false)
-                    
-                    
->>>>>>> 59282ce (final commit before rebase hopefully - added brownout buttons, better button feedback for endgame screen, as well as reworking how recording climbs work w the start climb button)
+                    setClimbStarted(false)                                
                   }}
-                  disabled={checkActionButtonDisabled()}
+                  disabled={checkActionButtonDisabled() || screenDisabled || climbStarted === false}
                   label="Shallow Hang"
                 />
 
@@ -230,7 +202,6 @@ export default function EndgameScreen() {
                   location={hangPositionSelected}
                   className={popoverButton2Style}
                   onClick={() => {
-<<<<<<< HEAD
                     setActionDone(true);
                     setCurrentAction("Deep Climb Failed");
                     setIsMatchSelectionOpen(false);
@@ -239,16 +210,14 @@ export default function EndgameScreen() {
                       positionSelected: hangPositionSelected,
                       actionMessage: "Deep Climb Failed",
                     });
-=======
                     toast.error("Robot failed deep climb!");
                     setCurrentAction("Deep Climb Failed");
                     setTimeout(() => setIsMatchSelectionOpen(false),500)
                     setPopoverButton2Style("mb-1 h-16 w-40 font-bold text-xl !bg-white !text-black");
                     setTimeout(() => setPopoverButton2Style("mb-1 h-16 w-40 font-bold text-xl !bg-pink-600 !text-white"),1000);
                     setClimbStarted(false)
->>>>>>> 59282ce (final commit before rebase hopefully - added brownout buttons, better button feedback for endgame screen, as well as reworking how recording climbs work w the start climb button)
                   }}
-                  disabled={checkActionButtonDisabled()}
+                  disabled={checkActionButtonDisabled() || screenDisabled || climbStarted === false}
                   label="Deep Hang"
                 />
               </PopoverContent>
@@ -257,26 +226,19 @@ export default function EndgameScreen() {
               actionName={ACTION_NAMES.CLIMB.NOTHING}
               gamePiece={GAME_PIECES.NOGAMEPIECE}
               location={hangPositionSelected}
-<<<<<<< HEAD
-              className=" mb-1 h-16 w-40 font-bold text-xl bg-pink-600"
-              disabled={checkActionButtonDisabled()}
+              className={button4Style}
+              disabled={checkActionButtonDisabled() || screenDisabled || climbStarted}
               onClick={() => {
                 setActionDone(true);
+                toast.error("Robot did not attempt endgame action!");
                 setCurrentAction("Endgame action skipped");
                 context.setPreviousEndgameAction({
                   actionDone: true,
                   positionSelected: hangPositionSelected,
                   actionMessage: "Endgame action skipped",
                 });
-=======
-              className={button4Style}
-              disabled={hangPositionSelected === "" || screenDisabled || climbStarted}
-              onClick={() => {
-                toast.error("Robot did not attempt endgame action!");
-                setCurrentAction("Endgame action skipped");
                 setButton4Style("mb-1 h-16 w-40 font-bold text-xl bg-white text-black")
                 setTimeout(() => setButton4Style("mb-1 h-16 w-40 font-bold text-xl bg-blue-600"),500)
->>>>>>> 59282ce (final commit before rebase hopefully - added brownout buttons, better button feedback for endgame screen, as well as reworking how recording climbs work w the start climb button)
               }}
               label="Not Attempted"
             />
@@ -288,7 +250,7 @@ export default function EndgameScreen() {
               gamePiece={GAME_PIECES.NOGAMEPIECE}
               location={hangPositionSelected}
               className={startClimbButtonStyle}
-              disabled={hangPositionSelected == "" || climbStarted === true || screenDisabled}
+              disabled={checkActionButtonDisabled() || climbStarted === true || screenDisabled}
               onClick={() => {
                 toast.error("Climb started!");
                 setCurrentAction("Started Climb Attempt");
@@ -320,12 +282,8 @@ export default function EndgameScreen() {
                 setPositionSelected(true);
                 setHangPositionSelected(LOCATIONS.BARGE.OUTER);
               }}
-<<<<<<< HEAD
-              disabled={hangPositionSelected !== ""}
-=======
 
               disabled={screenDisabled}
->>>>>>> 59282ce (final commit before rebase hopefully - added brownout buttons, better button feedback for endgame screen, as well as reworking how recording climbs work w the start climb button)
             >
               Far Cage
             </Button>
@@ -339,11 +297,7 @@ export default function EndgameScreen() {
                 setHangPositionSelected(LOCATIONS.BARGE.MIDDLE);
                 setPositionSelected(true);
               }}
-<<<<<<< HEAD
-              disabled={hangPositionSelected !== ""}
-=======
               disabled={screenDisabled}
->>>>>>> 59282ce (final commit before rebase hopefully - added brownout buttons, better button feedback for endgame screen, as well as reworking how recording climbs work w the start climb button)
             >
               Middle Cage
             </Button>
@@ -357,11 +311,7 @@ export default function EndgameScreen() {
                 setPositionSelected(true);
                 setHangPositionSelected(LOCATIONS.BARGE.INNER);
               }}
-<<<<<<< HEAD
-              disabled={hangPositionSelected !== ""}
-=======
               disabled={screenDisabled}
->>>>>>> 59282ce (final commit before rebase hopefully - added brownout buttons, better button feedback for endgame screen, as well as reworking how recording climbs work w the start climb button)
             >
               Near Cage
             </Button>
@@ -395,7 +345,6 @@ export default function EndgameScreen() {
             } 
     
           }}
-
 
         />
 

--- a/src/app/scout/[eventCode]/components/teleop-scoring-screen.tsx
+++ b/src/app/scout/[eventCode]/components/teleop-scoring-screen.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useContext, useState } from "react";
+import { useContext } from "react";
 import { ScoutDataContext, ScoutScreenContext } from "../context";
 import PageHeading from "~/components/common/page-heading";
 import MatchScoutingLayout from "./common/match-scouting-layout";
@@ -15,8 +15,6 @@ import { toast } from "sonner";
 const TeleopScoringScreen = () => {
   const context = useContext(ScoutDataContext);
   const screenContext = useContext(ScoutScreenContext);
-  const [brownOutLabel, setBrownOutLabel] = useState("BROWNOUT");
-  const [screenDisabled, setScreenDisabled] = useState(false);
 
   return (
     <>
@@ -33,7 +31,7 @@ const TeleopScoringScreen = () => {
           />
         </div>
       </div>
-      <MatchScoutingLayout isDisabled={screenDisabled} />
+      <MatchScoutingLayout isDisabled={context.isBrownedOut} />
       <div className="flex flex-row gap-3 justify-end w-full">
         <Button
           className={cn(
@@ -69,20 +67,21 @@ const TeleopScoringScreen = () => {
 
         <ScoutActionButton
           className="bg-red-500 flex items-center justify-center text-black font-bold text-xl h-20 w-64 px-4 py-2"
-          actionName={ACTION_NAMES.BROWN_OUT}
+          actionName={
+            context.isBrownedOut
+              ? ACTION_NAMES.BROWN_OUT_END
+              : ACTION_NAMES.BROWN_OUT
+          }
           gamePiece="null"
           location="null"
-          label={brownOutLabel}
+          label={context.isBrownedOut ? "ROBOT RESTARTED" : "BROWNOUT"}
           onClick={() => {
-            if (screenDisabled == false) {
-              setScreenDisabled(true);
-              toast.error("Robot has stopped. Screen disabled!");
-              setBrownOutLabel("ROBOT RESTARTED");
-            } else {
-              setScreenDisabled(false);
-              toast.error("Robot has restarted. Screen enabled!");
-              setBrownOutLabel("BROWNOUT");
-            }
+            toast.error(
+              context.isBrownedOut
+                ? "Robot has restarted. Screen enabled!"
+                : "Robot has stopped. Screen disabled!"
+            );
+            context.setIsBrownedOut(!context.isBrownedOut);
           }}
         />
 

--- a/src/app/scout/[eventCode]/components/teleop-scoring-screen.tsx
+++ b/src/app/scout/[eventCode]/components/teleop-scoring-screen.tsx
@@ -1,6 +1,7 @@
-"use client";
+        "use client";
 
-import { useContext } from "react";
+<<<<<<< HEAD
+import { useContext, useState } from "react";
 import { ScoutDataContext, ScoutScreenContext } from "../context";
 import PageHeading from "~/components/common/page-heading";
 import MatchScoutingLayout from "./common/match-scouting-layout";
@@ -10,10 +11,13 @@ import ScoutActionButton from "./common/scout-action-button";
 import { ACTION_NAMES, GAME_PIECES, LOCATIONS } from "../constants";
 import { Button } from "~/components/ui/button";
 import { cn } from "~/lib/utils";
+import { toast } from "sonner";
 
 const TeleopScoringScreen = () => {
   const context = useContext(ScoutDataContext);
   const screenContext = useContext(ScoutScreenContext);
+  const [brownOutLabel, setBrownOutLabel] = useState("BROWNOUT")
+  const [screenDisabled, setScreenDisabled] = useState(false);
 
   return (
     <>
@@ -30,7 +34,7 @@ const TeleopScoringScreen = () => {
           />
         </div>
       </div>
-      <MatchScoutingLayout isDisabled={false} />
+      <MatchScoutingLayout isDisabled={screenDisabled} />
       <div className="flex flex-row gap-3 justify-end w-full">
         <Button
           className={cn(
@@ -64,6 +68,29 @@ const TeleopScoringScreen = () => {
           }}
         />
 
+<ScoutActionButton
+                className="bg-red-500 flex items-center justify-center text-black font-bold text-xl h-20 w-64 px-4 py-2"
+                actionName={ACTION_NAMES.BROWN_OUT}
+                gamePiece="null"
+                location="null"
+                label={brownOutLabel}
+                onClick={() => {
+                  if (screenDisabled == false){
+                    setScreenDisabled(true);
+                    toast.error("Robot has stopped. Screen disabled!");
+                    setBrownOutLabel("ROBOT RESTARTED")
+      
+                  }
+                  else{
+                    setScreenDisabled(false)
+                    toast.error("Robot has restarted. Screen enabled!");
+                    setBrownOutLabel("BROWNOUT")
+                  } 
+          
+                }}
+
+                  />
+
         <div className="flex grow justify-end">
           <ContinueButton
             onClick={() => {
@@ -77,5 +104,61 @@ const TeleopScoringScreen = () => {
     </>
   );
 };
+=======
+    
 
-export default TeleopScoringScreen;
+        const TeleopScoringScreen = () => {
+
+
+          return (
+            <>
+              <div className="flex flex-row justify-between">
+                <div className="flex flex-row items-center space-x-4">
+                  <PageHeading>Teleop</PageHeading>
+                  <UndoActionButton className="text-2xl font-bold w-36 h-16 dark:bg-red-600" />
+                </div>
+              </div>
+              <MatchScoutingLayout isDisabled={screenDisabled} />
+              <div className="flex flex-row justify-between">
+>>>>>>> 59282ce (final commit before rebase hopefully - added brownout buttons, better button feedback for endgame screen, as well as reworking how recording climbs work w the start climb button)
+
+
+              <ScoutActionButton
+                className="bg-red-500 flex items-center justify-center text-black font-bold text-xl h-20 w-64 px-4 py-2"
+                actionName={ACTION_NAMES.BROWN_OUT}
+                gamePiece="null"
+                location="null"
+                label={brownOutLabel}
+                onClick={() => {
+                  if (screenDisabled == false){
+                    setScreenDisabled(true);
+                    toast.error("Robot has stopped. Screen disabled!");
+                    setBrownOutLabel("ROBOT RESTARTED")
+      
+                  }
+                  else{
+                    setScreenDisabled(false)
+                    toast.error("Robot has restarted. Screen enabled!");
+                    setBrownOutLabel("BROWNOUT")
+                  } 
+          
+                }}
+
+                  />
+                  
+                <ContinueButton
+                  onClick={() => {
+                    screenContext.nextScreen();
+                  }}
+
+                />
+
+                
+
+                
+              </div>
+            </>
+          );
+        };
+
+        export default TeleopScoringScreen;

--- a/src/app/scout/[eventCode]/components/teleop-scoring-screen.tsx
+++ b/src/app/scout/[eventCode]/components/teleop-scoring-screen.tsx
@@ -1,6 +1,5 @@
         "use client";
 
-<<<<<<< HEAD
 import { useContext, useState } from "react";
 import { ScoutDataContext, ScoutScreenContext } from "../context";
 import PageHeading from "~/components/common/page-heading";
@@ -68,7 +67,7 @@ const TeleopScoringScreen = () => {
           }}
         />
 
-<ScoutActionButton
+        <ScoutActionButton
                 className="bg-red-500 flex items-center justify-center text-black font-bold text-xl h-20 w-64 px-4 py-2"
                 actionName={ACTION_NAMES.BROWN_OUT}
                 gamePiece="null"
@@ -86,10 +85,8 @@ const TeleopScoringScreen = () => {
                     toast.error("Robot has restarted. Screen enabled!");
                     setBrownOutLabel("BROWNOUT")
                   } 
-          
                 }}
-
-                  />
+         />
 
         <div className="flex grow justify-end">
           <ContinueButton
@@ -104,61 +101,5 @@ const TeleopScoringScreen = () => {
     </>
   );
 };
-=======
-    
-
-        const TeleopScoringScreen = () => {
-
-
-          return (
-            <>
-              <div className="flex flex-row justify-between">
-                <div className="flex flex-row items-center space-x-4">
-                  <PageHeading>Teleop</PageHeading>
-                  <UndoActionButton className="text-2xl font-bold w-36 h-16 dark:bg-red-600" />
-                </div>
-              </div>
-              <MatchScoutingLayout isDisabled={screenDisabled} />
-              <div className="flex flex-row justify-between">
->>>>>>> 59282ce (final commit before rebase hopefully - added brownout buttons, better button feedback for endgame screen, as well as reworking how recording climbs work w the start climb button)
-
-
-              <ScoutActionButton
-                className="bg-red-500 flex items-center justify-center text-black font-bold text-xl h-20 w-64 px-4 py-2"
-                actionName={ACTION_NAMES.BROWN_OUT}
-                gamePiece="null"
-                location="null"
-                label={brownOutLabel}
-                onClick={() => {
-                  if (screenDisabled == false){
-                    setScreenDisabled(true);
-                    toast.error("Robot has stopped. Screen disabled!");
-                    setBrownOutLabel("ROBOT RESTARTED")
-      
-                  }
-                  else{
-                    setScreenDisabled(false)
-                    toast.error("Robot has restarted. Screen enabled!");
-                    setBrownOutLabel("BROWNOUT")
-                  } 
-          
-                }}
-
-                  />
-                  
-                <ContinueButton
-                  onClick={() => {
-                    screenContext.nextScreen();
-                  }}
-
-                />
-
-                
-
-                
-              </div>
-            </>
-          );
-        };
 
         export default TeleopScoringScreen;

--- a/src/app/scout/[eventCode]/components/teleop-scoring-screen.tsx
+++ b/src/app/scout/[eventCode]/components/teleop-scoring-screen.tsx
@@ -1,4 +1,4 @@
-        "use client";
+"use client";
 
 import { useContext, useState } from "react";
 import { ScoutDataContext, ScoutScreenContext } from "../context";
@@ -15,7 +15,7 @@ import { toast } from "sonner";
 const TeleopScoringScreen = () => {
   const context = useContext(ScoutDataContext);
   const screenContext = useContext(ScoutScreenContext);
-  const [brownOutLabel, setBrownOutLabel] = useState("BROWNOUT")
+  const [brownOutLabel, setBrownOutLabel] = useState("BROWNOUT");
   const [screenDisabled, setScreenDisabled] = useState(false);
 
   return (
@@ -68,25 +68,23 @@ const TeleopScoringScreen = () => {
         />
 
         <ScoutActionButton
-                className="bg-red-500 flex items-center justify-center text-black font-bold text-xl h-20 w-64 px-4 py-2"
-                actionName={ACTION_NAMES.BROWN_OUT}
-                gamePiece="null"
-                location="null"
-                label={brownOutLabel}
-                onClick={() => {
-                  if (screenDisabled == false){
-                    setScreenDisabled(true);
-                    toast.error("Robot has stopped. Screen disabled!");
-                    setBrownOutLabel("ROBOT RESTARTED")
-      
-                  }
-                  else{
-                    setScreenDisabled(false)
-                    toast.error("Robot has restarted. Screen enabled!");
-                    setBrownOutLabel("BROWNOUT")
-                  } 
-                }}
-         />
+          className="bg-red-500 flex items-center justify-center text-black font-bold text-xl h-20 w-64 px-4 py-2"
+          actionName={ACTION_NAMES.BROWN_OUT}
+          gamePiece="null"
+          location="null"
+          label={brownOutLabel}
+          onClick={() => {
+            if (screenDisabled == false) {
+              setScreenDisabled(true);
+              toast.error("Robot has stopped. Screen disabled!");
+              setBrownOutLabel("ROBOT RESTARTED");
+            } else {
+              setScreenDisabled(false);
+              toast.error("Robot has restarted. Screen enabled!");
+              setBrownOutLabel("BROWNOUT");
+            }
+          }}
+        />
 
         <div className="flex grow justify-end">
           <ContinueButton
@@ -102,4 +100,4 @@ const TeleopScoringScreen = () => {
   );
 };
 
-        export default TeleopScoringScreen;
+export default TeleopScoringScreen;

--- a/src/app/scout/[eventCode]/constants.ts
+++ b/src/app/scout/[eventCode]/constants.ts
@@ -17,9 +17,13 @@ export enum MATCH_STATES {
 
 export const ACTION_NAMES = {
   A_STOP: "a-stop",
+<<<<<<< HEAD
   MATCH_START: "match-start",
   AUTO_COMPLETE: "auto-complete",
   TELEOP_START: "teleop-start",
+=======
+  BROWN_OUT: "brown_out",
+>>>>>>> 59282ce (final commit before rebase hopefully - added brownout buttons, better button feedback for endgame screen, as well as reworking how recording climbs work w the start climb button)
   UNDO: "undo",
   OUTTAKE: "outtake",
   DISLODGE: "dislodge",
@@ -28,6 +32,7 @@ export const ACTION_NAMES = {
   DROP: "drop",
   MISS: "miss",
   CLIMB: {
+    START: "climb-start",
     ATTEMPT: "climb-attempt",
     SUCCESS: "climb-success",
     FAIL: "climb-fail",

--- a/src/app/scout/[eventCode]/constants.ts
+++ b/src/app/scout/[eventCode]/constants.ts
@@ -17,13 +17,10 @@ export enum MATCH_STATES {
 
 export const ACTION_NAMES = {
   A_STOP: "a-stop",
-<<<<<<< HEAD
   MATCH_START: "match-start",
   AUTO_COMPLETE: "auto-complete",
   TELEOP_START: "teleop-start",
-=======
   BROWN_OUT: "brown_out",
->>>>>>> 59282ce (final commit before rebase hopefully - added brownout buttons, better button feedback for endgame screen, as well as reworking how recording climbs work w the start climb button)
   UNDO: "undo",
   OUTTAKE: "outtake",
   DISLODGE: "dislodge",

--- a/src/app/scout/[eventCode]/constants.ts
+++ b/src/app/scout/[eventCode]/constants.ts
@@ -20,7 +20,8 @@ export const ACTION_NAMES = {
   MATCH_START: "match-start",
   AUTO_COMPLETE: "auto-complete",
   TELEOP_START: "teleop-start",
-  BROWN_OUT: "brown_out",
+  BROWN_OUT: "brown-out",
+  BROWN_OUT_END: "brown-out-end",
   UNDO: "undo",
   OUTTAKE: "outtake",
   DISLODGE: "dislodge",
@@ -72,6 +73,7 @@ export const LOCATIONS = {
     OUTER: "outer-barge",
     MIDDLE: "middle-barge",
     INNER: "inner-barge",
+    BASE: "barge",
   },
 };
 

--- a/src/app/scout/[eventCode]/context/data-context.tsx
+++ b/src/app/scout/[eventCode]/context/data-context.tsx
@@ -98,6 +98,8 @@ interface ScoutDataContextType {
   setHasLeftStartingLine: (hasLeftStartingLine: boolean) => void;
   isAutoStopped: boolean;
   setIsAutoStopped: (isAutoStopped: boolean) => void;
+  isBrownedOut: boolean;
+  setIsBrownedOut: (isBrownedOut: boolean) => void;
 }
 export const ScoutDataContext = createContext<ScoutDataContextType>(
   {} as ScoutDataContextType

--- a/src/app/scout/[eventCode]/page.tsx
+++ b/src/app/scout/[eventCode]/page.tsx
@@ -94,6 +94,7 @@ const ScoutPage = () => {
   const [isDefending, setIsDefending] = useState(false);
   const [hasLeftStartingLine, setHasLeftStartingLine] = useState(false);
   const [isAutoStopped, setIsAutoStopped] = useState(false);
+  const [isBrownedOut, setIsBrownedOut] = useState(false);
   const [matchSchedule, setMatchSchedule] = useState<MatchScheduleType[]>([]);
   const [currentMatch, setCurrentMatch] = useState<MatchScheduleType>();
   const [currentScreenIndex, setCurrentScreenIndex] = useState(0);
@@ -283,6 +284,8 @@ const ScoutPage = () => {
           setHasLeftStartingLine,
           isAutoStopped,
           setIsAutoStopped,
+          isBrownedOut,
+          setIsBrownedOut,
         }}
       >
         <ScoutingInfoHeader />


### PR DESCRIPTION


**### Brownout**

Made and implemented brownout / restart button to tele-op and endgame screen. Logs that the robot has died and disables entire screen until the button is clicked again, signalling that the robot restarted. 

![001](https://github.com/user-attachments/assets/1042778f-fa4e-4800-b31c-5307a738d73c)
![002](https://github.com/user-attachments/assets/76dd799a-8850-40dc-b034-a7766b917fb6)

**### Endgame Tweaks**

Made the buttons on the endgame screen visually responsive with on-click feedback and a toast message so scouts don't
get confused.
![image](https://github.com/user-attachments/assets/4f7cadcc-044d-4c78-aa9d-7f3fa6ce96e8)
![image](https://github.com/user-attachments/assets/90def087-abae-46ad-9c83-30607c151ab8)

Added a "Start Climb" button. Lets the scout know by the end how long the climb action took (regardless if it succeeded or
failed). Scouts now have to let the app know that the climb has started before being able to log the specific action (shallow,
deep, failed)

![image](https://github.com/user-attachments/assets/22d39a66-4395-4aa2-979a-56fde3d779a5)
![image](https://github.com/user-attachments/assets/cb8b348e-c53a-4ccd-9040-35deb19701c8)
![image](https://github.com/user-attachments/assets/fb8cbea2-6ccd-4084-91e2-ac6b3259c697)
![image](https://github.com/user-attachments/assets/7f4ce8a1-c7dd-4860-b5ba-e97c434961ff)

**### Misc:**

Changed header to say "Most Recent" instead of "Current Action" in order to avoid confusion with the new toast messages.
Separated climb and non climb actions by colour to avoid disorientation when the buttons toggle / untoggle themselves. 
Added new actions in constants.ts for the brownout and start climb button. 