### PR TITLE
bringing back the glory of the continue buttons

### DIFF
--- a/src/app/scout/[eventCode]/components/autonomous-screen.tsx
+++ b/src/app/scout/[eventCode]/components/autonomous-screen.tsx
@@ -72,6 +72,7 @@ export default function AutonomousScreen() {
             screenContext.nextScreen();
           }}
           disabled={context.isTimerRunning}
+          shouldShowIcon
         />
       </div>
     </>

--- a/src/app/scout/[eventCode]/components/endgame-screen.tsx
+++ b/src/app/scout/[eventCode]/components/endgame-screen.tsx
@@ -341,6 +341,7 @@ export default function EndgameScreen() {
           onClick={() => {
             screenContext.nextScreen();
           }}
+          shouldShowIcon
         />
       </div>
     </>

--- a/src/app/scout/[eventCode]/components/match-selection-screen.tsx
+++ b/src/app/scout/[eventCode]/components/match-selection-screen.tsx
@@ -133,6 +133,7 @@ export default function MatchSelectionScreen() {
               screenContext.nextScreen();
             }
           }}
+          shouldShowIcon
         />
       </div>
     </>

--- a/src/app/scout/[eventCode]/components/starting-position-screen.tsx
+++ b/src/app/scout/[eventCode]/components/starting-position-screen.tsx
@@ -243,6 +243,7 @@ export default function StartingPositionScreen() {
               });
             }}
             disabled={isContinueDisabled()}
+            label="START MATCH"
           />
         </div>
       </div>

--- a/src/app/scout/[eventCode]/components/teleop-scoring-screen.tsx
+++ b/src/app/scout/[eventCode]/components/teleop-scoring-screen.tsx
@@ -92,6 +92,7 @@ const TeleopScoringScreen = () => {
               context.setWasDefended(false);
               screenContext.nextScreen();
             }}
+            shouldShowIcon
           />
         </div>
       </div>


### PR DESCRIPTION
literally nothing to do so im making up tasks 
<img width="245" alt="image" src="https://github.com/user-attachments/assets/8b710421-f59b-48f9-8201-78998ec63c86" />
my wonderful arrows are back
<img width="751" alt="image" src="https://github.com/user-attachments/assets/ea936ac8-c709-40fd-beb5-538f58697934" />
changed continue to start match on starting-position-screen so its less confusing for user